### PR TITLE
Separate capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,98 +1,135 @@
-# Pepr Module
+# Pepr Module for Keycloak and Authservice
 
-This is a Pepr Module intended to be imported into your own Pepr Module. [Pepr](https://github.com/defenseunicorns/pepr) is a Kubernetes transformation system written in Typescript. To use this module:
+This is a Pepr Module intended to be imported into your own Pepr Module. [Pepr](https://github.com/defenseunicorns/pepr) is a Kubernetes transformation system written in Typescript. 
+<br>
+This repo has two capabilities in it that can be imported separately, or used together.
+1. Keycloak capability communicates with the keycloak deployed in cluster to generate a new client secret that will be picked up by the authservice module.
+2. Authservice capability reads from secrets created by the Keycloak module or manually and updates authservice's config.
+<br>
+These capability working together are designed to automate the manual steps required to integrate new applications into the [Big Bang IdAM Solution](https://docs-bigbang.dso.mil/latest/docs/understanding-bigbang/package-architecture/authservice/). If you wish to use this capability with the open source charts/images for this, there will be some changes that will need to be made:
+1. authservice does not have a public chart, only an [example](https://github.com/istio-ecosystem/authservice/tree/master/bookinfo-example/authservice). Changes will need to be made to make this work. You should start with the [bigbang docs](https://docs-bigbang.dso.mil/2.2.0/docs/understanding-bigbang/package-architecture/authservice/) to help with the implementation
+2. There are assumptions that the Keycloak capability makes that are specific to work with the [bigbang keycloak chart](https://docs-bigbang.dso.mil/2.2.0/docs/understanding-bigbang/package-architecture/keycloak/#Keycloak). This code can function with some minor changes to work with other keycloak charts. Mostly around where the keycloak chart stores the local admin kubernetes secret which the capability uses to communicate with keycloak.
 
+## Installation To use this module:
 - run `npm i @pepr/keycloak-authsvc`.
-- add the import to your `pepr.ts` file: `import KeycloakAuthSvc from "@pepr/keycloak-authsvc"`.
-- add the KeycloakAuthSvc entry to the `PeprModule` capability array.
+- Update your pepr.ts to look like this, or add additional capabilities to your module.
+```typescript
+import { PeprModule } from "pepr";
+import { Keycloak } from "@pepr/keycloak-authsvc";
+import { AuthService } from "@pepr/keycloak-authsvc";
+import cfg from "./package.json";
 
-# Keycloak Istio Authsvc Capability
+new PeprModule(cfg, [Keycloak, AuthService]);
+```
 
-This capability is designed to automate the manual steps required to integrate new applications into the [Big Bang IdAM Solution](https://docs-bigbang.dso.mil/latest/docs/understanding-bigbang/package-architecture/authservice/)
+## Pre-reqs for Keycloak capability
+1. for CAC auth, keycloak needs to be installed per BigBang, and accessible via an ingress gateway that is configured to passthrough into keycloak for TLS termination in keycloak.
+2. if CAC auth is not required, the ingress gateway can perform TLS termination.
+3. Keycloak must be resolvable via `https://keycloak.${domain}` from within and outside of the cluster. 
 
-## Pre-reqs
+## Pre-reqs for Authservice capability
+1. Istio must be setup with Authservice per the configuration from the BigBang chart (all the authn, authz stuff is covered in there)
+2. AuthService must have the istio sidecar running
+3. The IDP (IE: Keycloak) must be resolvable via from within and outside of the cluster. 
 
-The installation must be complete for keycloak, authservice and istio. It's best to use the bigbang chart to deploy these.
-
-### Keycloak setup:
-
+## Keycloak setup:
 1. Must be resolvable via https://keycloak.${domain} (or whatever domain you setup) inside the cluster, authservice requires TLS even with MTLS.
 2. The admin user and password must be stored in a secret in namespace `keycloak`, object `keycloak-env`
 3. pepr does not need special access to this namespace beyond the mutating webhook.
 
-### authservice setup:
-
+## Authservice setup:
 1. must be in namespace authservice
 2. must have a secret called authservice that contains the config.json
 3. pepr needs needs access to this namespace
-   1. full access to secrets (to read/write the client secrets, and update the authservice config)
-   2. will roll the authservice deployment via a restartedAt label (patch)
+   1. full access to secrets (to read/write the client secrets, and update the authservice config).
+   2. will roll the authservice deployment via a checksum label (patch)
 
-### Istio setup:
-
+## Istio setup:
 1. must have it's mesh aware of authservice (in the `istio-system` namespace, configmap `istio`)
 2. Istio objects must be created by the istio setup
    1. peerauthentications.security.istio.io
    2. authorizationpolicies.security.istio.io (authz)
    3. requestauthentications.security.istio.io (authn)
 
-## How to trigger the SSO pepr module:
-
-### Realm setup:
-
-If the realm is not created, there are two ways to create a realm (the realm can be pre-created)
-
-1. From a secret, this will create a pain old demo realm, with no configuration
-
+## Realm setup:
+The realm should be created by the bigbang package, but if not, the Keycloak capability provides this. The best way to do this:
+1. Export configuration without clients to a JSON file
+2. Verify the JSON file has the configuration you want
+3. rename the JSON file to `realmJson`
+4. Follow the procedure below to create a configmap with the realm configuration. Since there should be no secrets in the realm configuration, it's safe to use a configmap.
+```bash
+    kubectl create configmap configrealm -n keycloak --from-file=realmJson --from-literal=domain=bigbang.dev
+    kubectl label configmap configrealm -n keycloak  pepr.dev/keycloak=createrealm
 ```
-    kubectl create secret generic configrealm -n keycloak --from-literal=realm=demo --from-literal=domain=bigbang.dev
-    kubectl label secret configrealm -n keycloak todo=createrealm
-```
+NOTE: Multiple realms have not been tested!
 
-2. From a configmap export, A realm exported with keycloak's UI, can be imported in this method. Recommended to not export the clients. In this case all the realm info will be imported. Any clients that are in this import will be ignored, and it's recommended to remove them to keep this export smaller, and more flexible. `Keycloak's database enforces some primary key issues, so importing more than one realm by modifying the realm name in the import is not recommended.`
+## Setting up an application to be secured with Keycloak/Authservice
+1. This assumes the application is secured with istio's sidecar, has a virtual service and a gateway. It should be accessible from outside the cluster without authenication. 
+2. To protect this application with Keycloak, you can add the following to the deployment (or possibly a statefulset). This should result in a 'Permission Denied' message when attempting to access the application.
 
-```
-kubectl create cm configrealm -n podinfo --from-file=realmJson --from-literal=domain=bigbang.dev
-kubectl label cm configrealm -n podinfo  todo=createrealm
-```
-
-### Client setup:
-
-Setting up a client for an application is the primary use of this module. To kick off the process, for an example app called `podinfo`
-
-Before this application can be secured, the application deployment/statefulset that will be secured (via istio virtual service/gateway), must have this in it's spec:
-
-```
+The modifications to the deployment will look like this:
+```yaml
 spec:
   template:
     metadata:
       labels:
         protect: keycloak
 ```
-
-All the virtual services, and the gateway should be setup during application deployment time. Before you create the client try to access the service externally and you should see a `permission denied` since it's not setup in authservice or keycloak yet.
-
+Here's a command that will perform that patch on an example application (podinfo in namespace podinfo)
+```shell
+kubectl patch deployment podinfo -n podinfo -p '{"spec":{"template":{"metadata":{"labels":{"protect":"keycloak"}}}}}'
 ```
-kubectl create secret generic configclient -n podinfo --from-literal=realm=demo --from-literal=id=podinfo --from-literal=name=podinfo --from-literal=domain=bigbang.dev
-kubectl label secret configclient -n podinfo  todo=createclient
+3. To start the process for creation of the secret from keycloak:
+```bash
+kubectl create secret generic configclient -n podinfo \
+  --from-literal=realm=baby-yoda \
+  --from-literal=id=podinfo \
+  --from-literal=name=podinfo \
+  --from-literal=domain=bigbang.dev \
+  --dry-run=client -o yaml | kubectl label --local -f - pepr.dev/keycloak=createclient -o yaml | kubectl apply -f -
 ```
+This performs the same action:
+```bash
+kubectl create secret generic configclient -n podinfo --from-literal=realm=baby-yoda --from-literal=id=podinfo --from-literal=name=podinfo --from-literal=domain=bigbang.dev
+kubectl label secret configclient -n podinfo  pepr.dev/keycloak=createclient
+```
+Did it work? If this command:
+```bash
+kubectl get secret podinfo-client -n podinfo -o yaml
+```
+returns the following, then the Keycloak capability functioned properly.
+(NOTE: the clientSecret will be generated by keycloak so will not look the same) 
+```yaml
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  labels:
+    pepr.dev/keycloak: oidcconfig
+  name: podinfo-client
+  namespace: podinfo
+data:
+  clientSecret: WlJUWjNDcW9MMEpHaHRKZVdqcVNHdGoxVVEwbHBwZEY=
+  domain: YmlnYmFuZy5kZXY=
+  id: ZGV2XzAwZWI4OTA0LTViODgtNGM2OC1hZDY3LWNlYzBkMmUwN2FhNl9wb2RpbmZv
+  name: cG9kaW5mbw==
+  realm: YmFieS15b2Rh
+  redirectUri: aHR0cHM6Ly9wb2RpbmZvLmJpZ2JhbmcuZGV2L2xvZ2lu
+```
+If the following is in the secret, then the AuthService capability also ran correctly.
+```yaml
+  annotations:
+    e4a35052-c138-55e4-94a7-bb942b1cddc7.pepr.dev/AuthService: succeeded
+```
+4. Verifying the application now requires authentication. What initially allowed no authentication after step 1, then access denied after step 2, should now properly authenicate a user (NOTE: you'll need a user in the realm to test it). 
 
-This performs several tasks:
+## Troubleshooting
+If you got to step 4 above and the authentication flow is not properly working, here are things to test:
+1. Can you login to the keycloak admin console? 
+2. Did you create a user in the realm? Can that user login to keycloak as well?
+3. Does keycloak and authservice have the sidecar container running with it?
+4. Is authservice running properly?
+5. is the new chain in authservice's secret there?
+6. Did authservice properly restart?
+7. Is the authn/authz stuff in istio properly setup?
 
-1. reads the kubernetes secret
-2. contacts keycloak to generate the client secret
-3. write the keycloak data into the `authservice` namespace with a secret called `mission-${name}` in this case it would be `mission-podinfo`
-4. regenerates the namespace `authservice` named secret `authservice` to include the new client secret in its configuration
-5. restarts the authservice deployment
-
-## Deployment
-
-TBD
-
-### How to deploy this module
-
-Use pepr build and pepr deploy
-
-### How to validate this module is working properly
-
-See above.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Pepr Module for Keycloak and Authservice
 
 This is a Pepr Module intended to be imported into your own Pepr Module. [Pepr](https://github.com/defenseunicorns/pepr) is a Kubernetes transformation system written in Typescript. 
-<br>
-This repo has two capabilities in it that can be imported separately, or used together.
+
+## This repo has two capabilities in it that can be imported separately, or used together.
 1. Keycloak capability communicates with the keycloak deployed in cluster to generate a new client secret that will be picked up by the authservice module.
 2. Authservice capability reads from secrets created by the Keycloak module or manually and updates authservice's config.
-<br>
+
 These capability working together are designed to automate the manual steps required to integrate new applications into the [Big Bang IdAM Solution](https://docs-bigbang.dso.mil/latest/docs/understanding-bigbang/package-architecture/authservice/). If you wish to use this capability with the open source charts/images for this, there will be some changes that will need to be made:
 1. authservice does not have a public chart, only an [example](https://github.com/istio-ecosystem/authservice/tree/master/bookinfo-example/authservice). Changes will need to be made to make this work. You should start with the [bigbang docs](https://docs-bigbang.dso.mil/2.2.0/docs/understanding-bigbang/package-architecture/authservice/) to help with the implementation
 2. There are assumptions that the Keycloak capability makes that are specific to work with the [bigbang keycloak chart](https://docs-bigbang.dso.mil/2.2.0/docs/understanding-bigbang/package-architecture/keycloak/#Keycloak). This code can function with some minor changes to work with other keycloak charts. Mostly around where the keycloak chart stores the local admin kubernetes secret which the capability uses to communicate with keycloak.

--- a/capabilities/authservice.ts
+++ b/capabilities/authservice.ts
@@ -43,9 +43,12 @@ When(a.Secret)
     await updateAuthServiceSecret();
   });
 
+// TODO: this does not work yet due to functionality in pepr, will be added back in later
+/*
 When(a.Secret)
   .IsDeleted()
   .WithLabel("pepr.dev/keycloak", "oidcconfig")
   .Then(async () => {
     await updateAuthServiceSecret();
   });
+*/

--- a/capabilities/authservice.ts
+++ b/capabilities/authservice.ts
@@ -20,7 +20,7 @@ function delay(ms: number): Promise<void> {
 // Update the authservice secret (triggers from previous capability)
 When(a.Secret)
   .IsCreatedOrUpdated()
-  .WithLabel("pepr", "oidcconfig")
+  .WithLabel("pepr.dev/keycloak", "oidcconfig")
   .Then(async request => {
     try {
       const k8sApi = new K8sAPI();
@@ -31,7 +31,7 @@ When(a.Secret)
         await delay(5000);
         const sha256Hash =
           await authserviceSecretBuilder.buildAuthserviceSecret(
-            "pepr=oidcconfig"
+            "pepr.dev/keycloak=oidcconfig"
           );
         await k8sApi.checksumDeployment(
           "authservice",

--- a/capabilities/authservice.ts
+++ b/capabilities/authservice.ts
@@ -29,11 +29,12 @@ When(a.Secret)
       setImmediate(async () => {
         // waiting 5 seconds for the previous objects to be created.
         await delay(5000);
-        await authserviceSecretBuilder.buildAuthserviceSecret("pepr=oidcconfig");
+        await authserviceSecretBuilder.buildAuthserviceSecret(
+          "pepr=oidcconfig"
+        );
         await k8sApi.restartDeployment("authservice", "authservice");
       });
     } catch (e) {
       Log.error(`error ${e}`);
     }
   });
- 

--- a/capabilities/authservice.ts
+++ b/capabilities/authservice.ts
@@ -29,10 +29,15 @@ When(a.Secret)
       setImmediate(async () => {
         // waiting 5 seconds for the previous objects to be created.
         await delay(5000);
-        const sha256Hash = await authserviceSecretBuilder.buildAuthserviceSecret(
-          "pepr=oidcconfig"
+        const sha256Hash =
+          await authserviceSecretBuilder.buildAuthserviceSecret(
+            "pepr=oidcconfig"
+          );
+        await k8sApi.checksumDeployment(
+          "authservice",
+          "authservice",
+          sha256Hash
         );
-        await k8sApi.checksumDeployment("authservice", "authservice", sha256Hash);
       });
     } catch (e) {
       Log.error(`error ${e}`);

--- a/capabilities/authservice.ts
+++ b/capabilities/authservice.ts
@@ -9,37 +9,43 @@ export const AuthService = new Capability({
   namespaces: [],
 });
 
-// TODO: add a workflow for deleting a client
-
 const { When } = AuthService;
 
-// temporary until we can have a post persisted builder
+// Watch should help us here.
 function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
-// Update the authservice secret (triggers from previous capability)
+
+// TODO: When we have Watch() this will be correct, as the secrets will be persisted.
+async function updateAuthServiceSecret() {
+  try {
+    const k8sApi = new K8sAPI();
+    const authserviceSecretBuilder = new AuthServiceSecretBuilder(k8sApi);
+    setImmediate(async () => {
+      // XXX:TODO: this isn't enough time. waiting 5 seconds for the previous objects to be created.
+      await delay(5000);
+      const sha256Hash = await authserviceSecretBuilder.buildAuthserviceSecret(
+        "pepr.dev/keycloak=oidcconfig"
+      );
+      await k8sApi.checksumDeployment("authservice", "authservice", sha256Hash);
+    });
+  } catch (e) {
+    Log.error(`error ${e}`);
+  }
+}
+
+// In the event that any secrets are changed that are used by authservice, regenerate the authservice secret
+// Created/Deleted/Updated.
 When(a.Secret)
   .IsCreatedOrUpdated()
   .WithLabel("pepr.dev/keycloak", "oidcconfig")
-  .Then(async request => {
-    try {
-      const k8sApi = new K8sAPI();
-      const authserviceSecretBuilder = new AuthServiceSecretBuilder(k8sApi);
-      // XXX: BDW: TODO: remove once we have a post persisted builder
-      setImmediate(async () => {
-        // waiting 5 seconds for the previous objects to be created.
-        await delay(5000);
-        const sha256Hash =
-          await authserviceSecretBuilder.buildAuthserviceSecret(
-            "pepr.dev/keycloak=oidcconfig"
-          );
-        await k8sApi.checksumDeployment(
-          "authservice",
-          "authservice",
-          sha256Hash
-        );
-      });
-    } catch (e) {
-      Log.error(`error ${e}`);
-    }
+  .Then(async () => {
+    await updateAuthServiceSecret();
+  });
+
+When(a.Secret)
+  .IsDeleted()
+  .WithLabel("pepr.dev/keycloak", "oidcconfig")
+  .Then(async () => {
+    await updateAuthServiceSecret();
   });

--- a/capabilities/authservice.ts
+++ b/capabilities/authservice.ts
@@ -29,10 +29,10 @@ When(a.Secret)
       setImmediate(async () => {
         // waiting 5 seconds for the previous objects to be created.
         await delay(5000);
-        await authserviceSecretBuilder.buildAuthserviceSecret(
+        const sha256Hash = await authserviceSecretBuilder.buildAuthserviceSecret(
           "pepr=oidcconfig"
         );
-        await k8sApi.restartDeployment("authservice", "authservice");
+        await k8sApi.checksumDeployment("authservice", "authservice", sha256Hash);
       });
     } catch (e) {
       Log.error(`error ${e}`);

--- a/capabilities/authservice.ts
+++ b/capabilities/authservice.ts
@@ -1,0 +1,64 @@
+import { Capability, Log, a } from "pepr";
+
+import { AuthServiceSecretBuilder } from "./lib/authservice/secretBuilder";
+import { K8sAPI } from "./lib/kubernetes-api";
+
+export const AuthService = new Capability({
+  name: "AuthService",
+  description: "Simple example to configure AuthService",
+  namespaces: [],
+});
+
+interface OidcClientK8sSecretData {
+  realm: string,
+  id: string,
+  name: string,
+  domain: string,
+  secret: string,
+  redirect_uri: string
+}
+
+// TODO: add a workflow for deleting a client
+
+const { When } = AuthService;
+
+// temporary until we can have a post persisted builder
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+// Update the authservice secret (triggers from previous capability)
+When(a.Secret)
+  .IsCreatedOrUpdated()
+  .WithLabel("done", "createclient")
+  .Then(async request => {
+    const newSecret: OidcClientK8sSecretData = {
+      realm: request.Raw.data.realm,
+      id: request.Raw.data.id,
+      name: request.Raw.data.name,
+      domain: request.Raw.data.domain,
+      secret: request.Raw.data.clientSecret,
+      redirect_uri: request.Raw.data.redirectUri
+    };
+
+    const k8sApi = new K8sAPI();
+    await k8sApi.createOrUpdateSecret(
+      `mission-${request.Raw.data.name}`,
+      "authservice",
+      newSecret as unknown as Record<string, string>
+    );
+
+    try {
+      const k8sApi = new K8sAPI();
+      const authserviceSecretBuilder = new AuthServiceSecretBuilder(k8sApi);
+      // XXX: BDW: TODO: remove once we have a post persisted builder
+      setImmediate(async () => {
+        // waiting 5 seconds for the previous objects to be created.
+        await delay(5000);
+        await authserviceSecretBuilder.buildAuthserviceSecret();
+        await k8sApi.restartDeployment("authservice", "authservice");
+      });
+    } catch (e) {
+      Log.error(`error ${e}`);
+    }
+  });
+ 

--- a/capabilities/keycloak.ts
+++ b/capabilities/keycloak.ts
@@ -38,8 +38,8 @@ When(a.Secret)
 // Import a realm from a configmap
 /* 
 Example steps:
-    kubectl create cm configrealm -n podinfo --from-file=realmJson --from-literal=domain=bigbang.dev
-    kubectl label cm configrealm -n podinfo  pepr.dev/keycloak=createrealm
+    kubectl create cm configrealm -n keycloak --from-file=realmJson --from-literal=domain=bigbang.dev
+    kubectl label cm configrealm -n keycloak  pepr.dev/keycloak=createrealm
 */
 When(a.ConfigMap)
   .IsCreatedOrUpdated()
@@ -103,6 +103,8 @@ When(a.Secret)
     }
   });
 
+// TODO: this does not work yet due to functionality in pepr, will be added back in later
+/*
 When(a.Secret)
   .IsDeleted()
   .WithLabel("pepr.dev/keycloak", "createclient")
@@ -119,3 +121,4 @@ When(a.Secret)
       Log.error(`error ${e.stack}`);
     }
   });
+*/

--- a/capabilities/keycloak.ts
+++ b/capabilities/keycloak.ts
@@ -78,7 +78,8 @@ When(a.Secret)
       const id = request.Raw.data.id;
       const name = request.Raw.data.name;
       const domain = request.Raw.data.domain;
-      const redirectUri = request.Raw.data.redirectUri || `https://${name}.${domain}/login`;
+      const redirectUri =
+        request.Raw.data.redirectUri || `https://${name}.${domain}/login`;
 
       const keycloakBaseUrl = `https://keycloak.${domain}/auth`;
 
@@ -100,7 +101,7 @@ When(a.Secret)
         name: request.Raw.data.name,
         domain: request.Raw.data.domain,
         clientSecret: clientSecret,
-        redirectUri: redirectUri
+        redirectUri: redirectUri,
       };
 
       const k8sApi = new K8sAPI();
@@ -108,9 +109,8 @@ When(a.Secret)
         `${newSecret.name}-client`,
         request.Raw.metadata.namespace,
         newSecret as unknown as Record<string, string>,
-        { pepr: "oidcconfig" },
-      )
-
+        { pepr: "oidcconfig" }
+      );
     } catch (e) {
       Log.error(`error ${e.stack}`);
     }

--- a/capabilities/keycloak.ts
+++ b/capabilities/keycloak.ts
@@ -23,8 +23,7 @@ Demo steps
 When(a.Secret)
   .IsCreatedOrUpdated()
   .InNamespace("keycloak")
-  .WithName("configrealm")
-  .WithLabel("todo", "createrealm")
+  .WithLabel("pepr.dev/keycloak", "createrealm")
   .Then(async request => {
     const realm = request.Raw.data.realm;
     const domain = request.Raw.data.domain;
@@ -32,8 +31,7 @@ When(a.Secret)
     const keycloakBaseUrl = `https://keycloak.${domain}/auth`;
     const kcAPI = new KcAPI(keycloakBaseUrl);
     await kcAPI.GetOrCreateRealm(realm);
-    request.RemoveLabel("todo");
-    request.SetLabel("done", "created");
+    request.SetLabel("pepr.dev/keycloak", "done");
   });
 
 // Import a realm from a configmap
@@ -45,8 +43,7 @@ Example steps:
 When(a.ConfigMap)
   .IsCreatedOrUpdated()
   .InNamespace("keycloak")
-  .WithName("configrealm")
-  .WithLabel("todo", "createrealm")
+  .WithLabel("pepr.dev/keycloak", "createrealm")
   .Then(async request => {
     try {
       const domain = request.Raw.data.domain;
@@ -54,8 +51,7 @@ When(a.ConfigMap)
 
       const kcAPI = new KcAPI(keycloakBaseUrl);
       await kcAPI.ImportRealm(request.Raw.data.realmJson);
-      request.RemoveLabel("todo");
-      request.SetLabel("done", "created");
+      request.SetLabel("pepr.dev/keycloak", "done");
     } catch (e) {
       Log.error(`error ${e}`);
       request.SetLabel("error", e.message);
@@ -70,8 +66,7 @@ Example steps:
 */
 When(a.Secret)
   .IsCreatedOrUpdated()
-  .WithName("configclient")
-  .WithLabel("todo", "createclient")
+  .WithLabel("pepr.dev/keycloak", "createclient")
   .Then(async request => {
     try {
       const realm = request.Raw.data.realm;
@@ -79,7 +74,7 @@ When(a.Secret)
       const name = request.Raw.data.name;
       const domain = request.Raw.data.domain;
       const redirectUri =
-        request.Raw.data.redirectUri || `https://${name}.${domain}/login`;
+        request.Raw.data.redirectUri || `https://${name}.${domain}`;
 
       const keycloakBaseUrl = `https://keycloak.${domain}/auth`;
 
@@ -92,8 +87,7 @@ When(a.Secret)
         redirectUri
       );
 
-      request.RemoveLabel("todo");
-      request.SetLabel("done", "createclient");
+      request.SetLabel("pepr.dev/keycloak", "done");
 
       const newSecret: OidcClientK8sSecretData = {
         realm: request.Raw.data.realm,
@@ -109,7 +103,7 @@ When(a.Secret)
         `${newSecret.name}-client`,
         request.Raw.metadata.namespace,
         newSecret as unknown as Record<string, string>,
-        { pepr: "oidcconfig" }
+        { "pepr.dev/keycloak": "oidcconfig" }
       );
     } catch (e) {
       Log.error(`error ${e.stack}`);

--- a/capabilities/keycloak.ts
+++ b/capabilities/keycloak.ts
@@ -74,7 +74,7 @@ When(a.Secret)
       const name = request.Raw.data.name;
       const domain = request.Raw.data.domain;
       const redirectUri =
-        request.Raw.data.redirectUri || `https://${name}.${domain}`;
+        request.Raw.data.redirectUri || `https://${name}.${domain}/login`;
 
       const keycloakBaseUrl = `https://keycloak.${domain}/auth`;
 

--- a/capabilities/lib/authservice/secretBuilder.ts
+++ b/capabilities/lib/authservice/secretBuilder.ts
@@ -35,7 +35,9 @@ export class AuthServiceSecretBuilder {
   }
 
   async buildAuthserviceSecret(labelSelector: string) {
-    const missionSecrets = await this.k8sApi.getSecretsByLabeSelector(labelSelector)
+    const missionSecrets = await this.k8sApi.getSecretsByLabeSelector(
+      labelSelector
+    );
 
     if (missionSecrets.length == 0) {
       return;

--- a/capabilities/lib/authservice/secretBuilder.ts
+++ b/capabilities/lib/authservice/secretBuilder.ts
@@ -36,7 +36,7 @@ export class AuthServiceSecretBuilder {
   }
 
   async buildAuthserviceSecret(labelSelector: string): Promise<string> {
-    const missionSecrets = await this.k8sApi.getSecretsByLabeSelector(
+    const missionSecrets = await this.k8sApi.getSecretsByLabelSelector(
       labelSelector
     );
 
@@ -61,7 +61,7 @@ export class AuthServiceSecretBuilder {
     const config = JSON.stringify(authserviceConfig);
     const configHash = createHash("sha256").update(config).digest("hex");
 
-    await this.k8sApi.createOrUpdateSecret(
+    await this.k8sApi.upsertSecret(
       this.authServiceNamespace,
       this.authServiceSecretName,
       { [this.authServiceConfigFileName]: config }

--- a/capabilities/lib/authservice/secretBuilder.ts
+++ b/capabilities/lib/authservice/secretBuilder.ts
@@ -1,7 +1,7 @@
 import { K8sAPI } from "../kubernetes-api";
 import { AuthserviceConfig } from "./secretConfig";
 import { V1Secret } from "@kubernetes/client-node";
-import { createHash } from "crypto"
+import { createHash } from "crypto";
 
 export class AuthServiceSecretBuilder {
   k8sApi: K8sAPI;
@@ -58,8 +58,8 @@ export class AuthServiceSecretBuilder {
       });
     });
 
-    const config = JSON.stringify(authserviceConfig)
-    const configHash = createHash('sha256').update(config).digest("hex");
+    const config = JSON.stringify(authserviceConfig);
+    const configHash = createHash("sha256").update(config).digest("hex");
 
     await this.k8sApi.createOrUpdateSecret(
       this.authServiceNamespace,
@@ -67,6 +67,6 @@ export class AuthServiceSecretBuilder {
       { [this.authServiceConfigFileName]: config }
     );
 
-    return configHash
+    return configHash;
   }
 }

--- a/capabilities/lib/authservice/secretBuilder.ts
+++ b/capabilities/lib/authservice/secretBuilder.ts
@@ -34,11 +34,9 @@ export class AuthServiceSecretBuilder {
     );
   }
 
-  async buildAuthserviceSecret() {
-    const missionSecrets = await this.k8sApi.getSecretsByPattern(
-      "mission-",
-      "authservice"
-    );
+  async buildAuthserviceSecret(labelSelector: string) {
+    const missionSecrets = await this.k8sApi.getSecretsByLabeSelector(labelSelector)
+
     if (missionSecrets.length == 0) {
       return;
     }
@@ -52,8 +50,8 @@ export class AuthServiceSecretBuilder {
         id,
         name,
         hostname: `${name}.${domain}`,
-        redirect_uri: this.decodeBase64(secret, "redirect_uri"),
-        secret: this.decodeBase64(secret, "secret"),
+        redirect_uri: this.decodeBase64(secret, "redirectUri"),
+        secret: this.decodeBase64(secret, "clientSecret"),
       });
     });
 

--- a/capabilities/lib/kc-api.ts
+++ b/capabilities/lib/kc-api.ts
@@ -142,7 +142,6 @@ export class KcAPI {
 
   private async GetClientSecret(
     realmName: string,
-    clientName: string,
     clientId: string
   ): Promise<string> {
     await this.connect();
@@ -189,7 +188,7 @@ export class KcAPI {
   ): Promise<string> {
     await this.connect();
 
-    const secret = await this.GetClientSecret(realmName, clientName, clientId);
+    const secret = await this.GetClientSecret(realmName, clientId);
     if (secret) {
       return secret;
     }
@@ -198,7 +197,7 @@ export class KcAPI {
     await this.CreateClient(clientId, clientName, redirectUri, realmName);
 
     //
-    return await this.GetClientSecret(realmName, clientName, clientId);
+    return await this.GetClientSecret(realmName, clientId);
   }
 
   private async CreateClient(
@@ -227,6 +226,21 @@ export class KcAPI {
 
     if (!response.ok) {
       throw new Error(`Failed to create client with clientId ${clientId}`);
+    }
+  }
+
+  async DeleteClient(clientId: string, realmName: string) {
+    const response = await fetch(
+      `${this.keycloakBaseUrl}/admin/realms/${realmName}/clients/${clientId}`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+        },
+      }
+    );
+    if (!response.ok) {
+      throw new Error(`Failed to delete client with clientId ${clientId}`);
     }
   }
 }

--- a/capabilities/lib/kubernetes-api.ts
+++ b/capabilities/lib/kubernetes-api.ts
@@ -68,12 +68,17 @@ export class K8sAPI {
 
   async getSecretsByLabeSelector(labelSelector: string): Promise<V1Secret[]> {
     // Get all secrets in the namespace
-    const secrets = await this.k8sApi.listSecretForAllNamespaces(null, null, null, labelSelector);
+    const secrets = await this.k8sApi.listSecretForAllNamespaces(
+      null,
+      null,
+      null,
+      labelSelector
+    );
     if (!secrets || !secrets.body || !secrets.body.items) {
       return [];
     }
 
-    return secrets.body.items
+    return secrets.body.items;
   }
 
   async createOrUpdateSecret(
@@ -89,7 +94,7 @@ export class K8sAPI {
       metadata: {
         name: name,
         namespace: namespace,
-        labels
+        labels,
       },
       data: {},
     };

--- a/capabilities/lib/kubernetes-api.ts
+++ b/capabilities/lib/kubernetes-api.ts
@@ -44,12 +44,12 @@ export class K8sAPI {
     throw new Error(`Could not retrieve the secret ${name}`);
   }
 
-  async restartDeployment(name: string, namespace: string) {
+  async checksumDeployment(name: string, namespace: string, checksum: string) {
     const patch = [
       {
         op: "add",
-        path: "/spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt",
-        value: new Date().toISOString(),
+        path: "/spec/template/metadata/annotations/pepr.dev~1checksum",
+        value: checksum,
       },
     ];
 

--- a/capabilities/lib/kubernetes-api.ts
+++ b/capabilities/lib/kubernetes-api.ts
@@ -66,28 +66,21 @@ export class K8sAPI {
     );
   }
 
-  async getSecretsByPattern(pattern: string, namespace: string) {
+  async getSecretsByLabeSelector(labelSelector: string): Promise<V1Secret[]> {
     // Get all secrets in the namespace
-    const secrets = await this.k8sApi.listNamespacedSecret(namespace);
+    const secrets = await this.k8sApi.listSecretForAllNamespaces(null, null, null, labelSelector);
     if (!secrets || !secrets.body || !secrets.body.items) {
       return [];
     }
 
-    // Filter the secrets by the provided pattern
-    const matchingSecrets = secrets.body.items.filter(
-      secret =>
-        secret.metadata &&
-        secret.metadata.name &&
-        secret.metadata.name.startsWith(pattern)
-    );
-
-    return matchingSecrets;
+    return secrets.body.items
   }
 
   async createOrUpdateSecret(
     name: string,
     namespace: string,
-    secretData: Record<string, string>
+    secretData: Record<string, string>,
+    labels?: { [key: string]: string }
   ) {
     // Prepare the Secret object
     const secret: V1Secret = {
@@ -96,6 +89,7 @@ export class K8sAPI {
       metadata: {
         name: name,
         namespace: namespace,
+        labels
       },
       data: {},
     };

--- a/capabilities/lib/kubernetes-api.ts
+++ b/capabilities/lib/kubernetes-api.ts
@@ -66,22 +66,17 @@ export class K8sAPI {
     );
   }
 
-  async getSecretsByLabeSelector(labelSelector: string): Promise<V1Secret[]> {
-    // Get all secrets in the namespace
+  async getSecretsByLabelSelector(labelSelector: string): Promise<V1Secret[]> {
     const secrets = await this.k8sApi.listSecretForAllNamespaces(
       null,
       null,
       null,
       labelSelector
     );
-    if (!secrets || !secrets.body || !secrets.body.items) {
-      return [];
-    }
-
-    return secrets.body.items;
+    return secrets?.body?.items || [];
   }
 
-  async createOrUpdateSecret(
+  async upsertSecret(
     name: string,
     namespace: string,
     secretData: Record<string, string>,

--- a/capabilities/lib/types.ts
+++ b/capabilities/lib/types.ts
@@ -1,8 +1,8 @@
 export interface OidcClientK8sSecretData {
-    realm: string,
-    id: string,
-    name: string,
-    domain: string,
-    clientSecret: string,
-    redirectUri: string
-  }
+  realm: string;
+  id: string;
+  name: string;
+  domain: string;
+  clientSecret: string;
+  redirectUri: string;
+}

--- a/capabilities/lib/types.ts
+++ b/capabilities/lib/types.ts
@@ -1,0 +1,8 @@
+export interface OidcClientK8sSecretData {
+    realm: string,
+    id: string,
+    name: string,
+    domain: string,
+    clientSecret: string,
+    redirectUri: string
+  }

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
 import { Keycloak } from "./capabilities/keycloak";
 import { AuthService } from "./capabilities/authservice";
 
-export { Keycloak, AuthService }
+export { Keycloak, AuthService };

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
-import { KeycloakAuthSvc } from "./capabilities/keycloak-authsvc";
+import { Keycloak } from "./capabilities/keycloak";
+import { AuthService } from "./capabilities/authservice";
 
-export default KeycloakAuthSvc;
+export { Keycloak, AuthService }

--- a/pepr.ts
+++ b/pepr.ts
@@ -1,5 +1,6 @@
 import { PeprModule } from "pepr";
-import { KeycloakAuthSvc } from "./capabilities/keycloak-authsvc";
+import { Keycloak } from "./capabilities/keycloak";
+import { AuthService } from "./capabilities/authservice";
 // cfg loads your pepr configuration from package.json
 import cfg from "./package.json";
 
@@ -7,4 +8,4 @@ import cfg from "./package.json";
  * This is the main entrypoint for this Pepr module. It is run when the module is started.
  * This is where you register your Pepr configurations and capabilities.
  */
-new PeprModule(cfg, [KeycloakAuthSvc]);
+new PeprModule(cfg, [Keycloak, AuthService]);


### PR DESCRIPTION
This MR:
* Separates Keycloak and AuthService into separate capabilities
* Updates labels to support multiple clients created per namespace
* Adds an sha256 hash of client configs to the authservice deployment to trigger pod rollouts on changes 
