### PR TITLE
Add logout data into the authservice chain

### DIFF
--- a/capabilities/lib/authservice/secretBuilder.ts
+++ b/capabilities/lib/authservice/secretBuilder.ts
@@ -48,12 +48,16 @@ export class AuthServiceSecretBuilder {
       const name = this.decodeBase64(secret, "name");
       const domain = this.decodeBase64(secret, "domain");
       const id = this.decodeBase64(secret, "id");
+      const realm = this.decodeBase64(secret, "realm");
+
       return AuthserviceConfig.createSingleChain({
         id,
         name,
         hostname: `${name}.${domain}`,
         redirect_uri: this.decodeBase64(secret, "redirect_uri"),
         secret: this.decodeBase64(secret, "secret"),
+        domain: domain,
+        realm: realm,
       });
     });
 

--- a/capabilities/lib/authservice/secretConfig.test.ts
+++ b/capabilities/lib/authservice/secretConfig.test.ts
@@ -1,6 +1,6 @@
 import test from "ava";
 import { AuthserviceConfig, ChainInput, Match } from "./secretConfig";
-import { OIDCConfig } from "./oidcSectionConfig";
+import { LogoutConfig, OIDCConfig } from "./oidcSectionConfig";
 
 test("AuthserviceConfig should handle input correctly", t => {
   const chainInput: ChainInput = {
@@ -9,6 +9,8 @@ test("AuthserviceConfig should handle input correctly", t => {
     hostname: "test.hostname",
     redirect_uri: "http://localhost:8080",
     secret: "secret",
+    domain: "example.com",
+    realm: "brown-bear",
   };
 
   const filterChain = AuthserviceConfig.createSingleChain(chainInput);
@@ -30,6 +32,13 @@ test("AuthserviceConfig should handle input correctly", t => {
   t.is(oidcConfig.client_id, chainInput.name);
   t.is(oidcConfig.client_secret, chainInput.secret);
   t.is(oidcConfig.cookie_name_prefix, chainInput.name);
+
+  const logoutConfig = oidcConfig.logout as LogoutConfig;
+  t.is(logoutConfig.path, "/logout");
+  t.is(
+    logoutConfig.redirect_uri,
+    "https://keycloak.example.com/auth/realms/brown-bear/protocol/openid-connect/logout?client_id=test"
+  );
 
   const json = {
     chains: [filterChain.toObject()],

--- a/capabilities/lib/authservice/secretConfig.ts
+++ b/capabilities/lib/authservice/secretConfig.ts
@@ -141,6 +141,8 @@ export interface ChainInput {
   redirect_uri: string;
   secret: string;
   id: string;
+  domain: string;
+  realm: string;
 }
 
 export class AuthserviceConfig {

--- a/capabilities/lib/authservice/secretConfig.ts
+++ b/capabilities/lib/authservice/secretConfig.ts
@@ -1,4 +1,4 @@
-import { OIDCConfig } from "./oidcSectionConfig";
+import { LogoutConfig, OIDCConfig } from "./oidcSectionConfig";
 
 export class StringMatch {
   exact?: string;
@@ -176,11 +176,17 @@ export class AuthserviceConfig {
   }
 
   static createSingleChain(input: ChainInput): FilterChain {
+    const logout = new LogoutConfig({
+      path: "/logout",
+      redirect_uri: `https://keycloak.${input.domain}/auth/realms/${input.realm}/protocol/openid-connect/logout?client_id=${input.id}`,
+    });
+
     const oidcConfig = new OIDCConfig({
       callback_uri: input.redirect_uri,
       client_id: input.id,
       client_secret: input.secret,
       cookie_name_prefix: input.name,
+      logout: logout,
     });
 
     const filter = new Filter({


### PR DESCRIPTION
This PR adds the logout fields in the authservice chain to enable an app (keycloak client) to hit the /logout resource to logout of keycloak.

The logout URI uses the format listed in keycloak docs:
https://www.keycloak.org/docs/latest/securing_apps/index.html#logout

Closes #53 