### PR TITLE
changes needed for pepr 0.13

### DIFF
--- a/.vscode/pepr.code-snippets
+++ b/.vscode/pepr.code-snippets
@@ -10,12 +10,12 @@
       "\tnamespaces: [${2:}],",
       "});",
       "",
-      "// Use the 'When' function to create a new Capability Action",
+      "// Use the 'When' function to create a new action",
       "const { When } = ${TM_FILENAME_BASE/(.*)/${1:/pascalcase}/};",
       "",
       "// When(a.<Kind>).Is<Event>().Then(change => change.<changes>",
       "When(${3:})"
     ],
-    "description": "Creates a new Pepr capability with a specified description, and optional namespaces, and adds a When statement for the specified value."
+    "description": "Creates a new Pepr capability with a specified description, optional namespaces, and adds a When statement for the specified value."
   }
 }

--- a/capabilities/authservice.ts
+++ b/capabilities/authservice.ts
@@ -1,11 +1,11 @@
-import { Capability, Log, a } from "pepr";
+import { Capability, a } from "pepr";
 
 import { AuthServiceSecretBuilder } from "./lib/authservice/secretBuilder";
 import { K8sAPI } from "./lib/kubernetes-api";
 
 export const AuthService = new Capability({
   name: "AuthService",
-  description: "Simple example to configure AuthService",
+  description: "Configures AuthService secret and restarts it to load it",
   namespaces: [],
 });
 
@@ -14,11 +14,10 @@ const { When } = AuthService;
 const k8sApi = new K8sAPI();
 const authserviceSecretBuilder = new AuthServiceSecretBuilder(k8sApi);
 
-// these will run in the backgeound
 When(a.Secret)
   .IsCreatedOrUpdated()
   .WithLabel("pepr.dev/keycloak", "oidcconfig")
-  .Then(async request => {
+  .Mutate(async request => {
     await authserviceSecretBuilder.update({
       secret: request.Raw,
       isDelete: false,
@@ -28,7 +27,7 @@ When(a.Secret)
 When(a.Secret)
   .IsDeleted()
   .WithLabel("pepr.dev/keycloak", "oidcconfig")
-  .Then(async request => {
+  .Mutate(async request => {
     await authserviceSecretBuilder.update({
       secret: request.OldResource,
       isDelete: true,

--- a/capabilities/keycloak.ts
+++ b/capabilities/keycloak.ts
@@ -1,11 +1,11 @@
-import { Capability, Log, a } from "pepr";
+import { Capability, Log, a, k8s } from "pepr";
 import { KcAPI } from "./lib/kc-api";
 import { K8sAPI } from "./lib/kubernetes-api";
 import { OidcClientK8sSecretData } from "./lib/types";
 
 export const Keycloak = new Capability({
   name: "Keycloak",
-  description: "Simple example to configure keycloak realm and clientid",
+  description: "Configures keycloak realm (two ways) and clientids",
   namespaces: [],
 });
 
@@ -25,7 +25,7 @@ When(a.Secret)
   .IsCreatedOrUpdated()
   .InNamespace("keycloak")
   .WithLabel("pepr.dev/keycloak", "createrealm")
-  .Then(async request => {
+  .Mutate(async request => {
     try {
       const kcAPI = new KcAPI(getKeyclockBaseURL(request.Raw.data.domain));
       await kcAPI.GetOrCreateRealm(request.Raw.data.realm);
@@ -44,7 +44,7 @@ When(a.ConfigMap)
   .IsCreatedOrUpdated()
   .InNamespace("keycloak")
   .WithLabel("pepr.dev/keycloak", "createrealm")
-  .Then(async request => {
+  .Mutate(async request => {
     try {
       const kcAPI = new KcAPI(getKeyclockBaseURL(request.Raw.data.domain));
       await kcAPI.ImportRealm(request.Raw.data.realmJson);
@@ -62,7 +62,7 @@ Example steps:
 When(a.Secret)
   .IsCreatedOrUpdated()
   .WithLabel("pepr.dev/keycloak", "createclient")
-  .Then(async request => {
+  .Validate(async request => {
     try {
       const redirectUri =
         request.Raw.data?.redirectUri ||
@@ -74,7 +74,7 @@ When(a.Secret)
         request.Raw.data.realm,
         request.Raw.data.name,
         request.Raw.data.id,
-        redirectUri
+        redirectUri,
       );
 
       const newSecret: OidcClientK8sSecretData = {
@@ -86,32 +86,37 @@ When(a.Secret)
         redirectUri: redirectUri,
       };
 
-      // TODO: Once this is an admission webhook (versus a mutating webhook, we will have the uid to set the ownerReference )
+      // will trigger deletion of the authservice secret
+      const ownerReference: k8s.V1OwnerReference = {
+        apiVersion: request.Raw.apiVersion,
+        uid: request.Raw.metadata.uid,
+        kind: request.Raw.kind,
+        name: request.Raw.metadata.name,
+      };
+
       const k8sApi = new K8sAPI();
       await k8sApi.upsertSecret(
         `${newSecret.name}-client`,
         request.Raw.metadata.namespace,
         newSecret as unknown as Record<string, string>,
-        { "pepr.dev/keycloak": "oidcconfig" }
+        [ownerReference],
+        { "pepr.dev/keycloak": "oidcconfig" },
       );
     } catch (e) {
+      return request.Deny(`error ${e}`);
       Log.error(`error ${e}`, "Keycloak.Client.Secret.IsCreatedOrUpdated()");
     }
+    return request.Approve();
   });
 
-// Delete the secret from keycloak, and remove the authservice
+// Delete the secret from keycloak
 When(a.Secret)
   .IsDeleted()
   .WithLabel("pepr.dev/keycloak", "createclient")
-  .Then(async request => {
+  .Mutate(async request => {
     try {
       const kcAPI = new KcAPI(getKeyclockBaseURL(request.Raw.data.domain));
       kcAPI.DeleteClient(request.Raw.data.id, request.Raw.data.realm);
-      const k8sApi = new K8sAPI();
-      await k8sApi.deleteSecret(
-        `${request.Raw.data.name}-client`,
-        request.Raw.metadata.namespace
-      );
     } catch (e) {
       Log.error(`error ${e}`, "Keycloak.Client.Secret.IsDeleted()");
     }

--- a/capabilities/lib/authservice/oidcSectionConfig.ts
+++ b/capabilities/lib/authservice/oidcSectionConfig.ts
@@ -1,8 +1,44 @@
+interface RedisConfigJSON {
+  server_uri: string;
+}
+
+interface LogoutConfigJSON {
+  path: string;
+  redirect_uri: string;
+}
+
+interface JwksFetcherConfigJSON {
+  jwks_uri: string;
+  periodic_fetch_interval_sec?: number;
+  skip_verify_peer_cert?: boolean;
+}
+
+export interface OIDCConfigJSON {
+  authorization_uri?: string;
+  token_uri?: string;
+  callback_uri: string;
+  client_id: string;
+  client_secret: string;
+  scopes?: string[];
+  cookie_name_prefix?: string;
+  id_token?: IdTokenConfig;
+  access_token?: AccessTokenConfig;
+  logout?: LogoutConfigJSON;
+  jwks?: string;
+  jwks_fetcher?: JwksFetcherConfigJSON;
+  absolute_session_timeout?: number;
+  idle_session_timeout?: number;
+  trusted_certificate_authority?: string;
+  proxy_uri?: string;
+  redis_session_store_config?: RedisConfig;
+  skip_verify_peer_cert?: boolean;
+}
+
 export class IdTokenConfig {
   header = "Authorization";
   preamble = "Bearer";
 
-  toObject(): Record<string, any> {
+  toObject() {
     return {
       header: this?.header,
       preamble: this?.preamble,
@@ -13,7 +49,7 @@ export class IdTokenConfig {
 export class AccessTokenConfig {
   header = "JWT";
 
-  toObject(): Record<string, any> {
+  toObject(): Record<string, string> {
     return {
       header: this.header,
     };
@@ -23,11 +59,11 @@ export class AccessTokenConfig {
 export class RedisConfig {
   server_uri: string;
 
-  constructor(json?: any) {
+  constructor(json?: RedisConfigJSON) {
     new URL(json.server_uri);
     this.server_uri = json.server_uri;
   }
-  toObject(): Record<string, any> {
+  toObject(): Record<string, string> {
     return {
       server_uri: this.server_uri,
     };
@@ -38,7 +74,7 @@ export class LogoutConfig {
   path: string;
   redirect_uri: string;
 
-  constructor(json: any) {
+  constructor(json: LogoutConfigJSON) {
     if (!json.path || json.path.length < 1) {
       throw new TypeError(
         "path is required and must be at least 1 character long",
@@ -56,7 +92,7 @@ export class LogoutConfig {
     this.path = json.path;
     this.redirect_uri = json.redirect_uri;
   }
-  toObject(): Record<string, any> {
+  toObject() {
     return {
       path: this.path,
       redirect_uri: this.redirect_uri,
@@ -69,7 +105,7 @@ export class JwksFetcherConfig {
   periodic_fetch_interval_sec?: number;
   skip_verify_peer_cert?: boolean;
 
-  constructor(json: any) {
+  constructor(json: JwksFetcherConfigJSON) {
     if (!json.jwks_uri) {
       throw new TypeError("jwks_uri is required");
     }
@@ -77,14 +113,10 @@ export class JwksFetcherConfig {
     new URL(json.jwks_uri);
 
     this.jwks_uri = json.jwks_uri;
-    if (json.periodic_fetch_interval_sec) {
-      this.periodic_fetch_interval_sec = json.periodic_fetch_interval_sec;
-    }
-    if (json.skip_verify_peer_cert) {
-      this.skip_verify_peer_cert = json.skip_verify_peer_cert;
-    }
+    this.periodic_fetch_interval_sec = json?.periodic_fetch_interval_sec;
+    this.skip_verify_peer_cert = json?.skip_verify_peer_cert;
   }
-  toObject(): Record<string, any> {
+  toObject() {
     return {
       jwks_uri: this.jwks_uri,
       periodic_fetch_interval_sec: this.periodic_fetch_interval_sec,
@@ -94,8 +126,8 @@ export class JwksFetcherConfig {
 }
 
 export class OIDCConfig {
-  authorization_uri: string;
-  token_uri: string;
+  authorization_uri?: string;
+  token_uri?: string;
   callback_uri: string;
   client_id: string;
   client_secret: string;
@@ -113,65 +145,45 @@ export class OIDCConfig {
   redis_session_store_config?: RedisConfig;
   skip_verify_peer_cert?: boolean;
 
-  constructor(json: any) {
-    this.authorization_uri = json.authorization_uri;
-    this.token_uri = json.token_uri;
+  constructor(json: OIDCConfigJSON) {
+    this.authorization_uri = json?.authorization_uri;
+    this.token_uri = json?.token_uri;
     this.callback_uri = json.callback_uri;
     this.client_id = json.client_id;
     this.client_secret = json.client_secret;
-    if (json.scopes) {
-      this.scopes = json.scopes;
-    }
+    this.scopes = json?.scopes;
 
-    if ("cookie_name_prefix" in json) {
-      this.cookie_name_prefix = json.cookie_name_prefix;
-    }
-
-    this.id_token = json.id_token;
-    this.access_token = json.access_token;
+    this.cookie_name_prefix = json?.cookie_name_prefix;
+    this.id_token = json?.id_token;
+    this.access_token = json?.access_token;
 
     if (json.logout) {
       this.logout = new LogoutConfig(json.logout);
     }
 
-    if (json.jwks) {
-      this.jwks = json.jwks;
-    }
+    this.jwks = json?.jwks;
 
     if (json.jwks_fetcher) {
       this.jwks_fetcher = new JwksFetcherConfig(json.jwks_fetcher);
     }
 
-    if (json.absolute_session_timeout) {
-      this.absolute_session_timeout = json.absolute_session_timeout;
-    }
-
-    if (json.idle_session_timeout) {
-      this.idle_session_timeout = json.idle_session_timeout;
-    }
-
-    if (json.trusted_certificate_authority) {
-      this.trusted_certificate_authority = json.trusted_certificate_authority;
-    }
+    this.absolute_session_timeout = json?.absolute_session_timeout;
+    this.idle_session_timeout = json?.idle_session_timeout;
+    this.trusted_certificate_authority = json?.trusted_certificate_authority;
 
     if (json.proxy_uri) {
       new URL(json.proxy_uri);
       this.proxy_uri = json.proxy_uri;
     }
 
-    if (json.redis_session_store_config) {
-      this.redis_session_store_config = json.redis_session_store_config;
-    }
-
-    if (json.skip_verify_peer_cert) {
-      this.skip_verify_peer_cert = json.skip_verify_peer_cert;
-    }
+    this.redis_session_store_config = json?.redis_session_store_config;
+    this.skip_verify_peer_cert = json?.skip_verify_peer_cert;
   }
 
-  toObject(): Record<string, any> {
+  toObject() {
     return {
-      authorization_uri: this.authorization_uri,
-      token_uri: this.token_uri,
+      authorization_uri: this?.authorization_uri,
+      token_uri: this?.token_uri,
       callback_uri: this.callback_uri,
       client_id: this.client_id,
       client_secret: this.client_secret,

--- a/capabilities/lib/authservice/oidcSectionConfig.ts
+++ b/capabilities/lib/authservice/oidcSectionConfig.ts
@@ -41,12 +41,12 @@ export class LogoutConfig {
   constructor(json: any) {
     if (!json.path || json.path.length < 1) {
       throw new TypeError(
-        "path is required and must be at least 1 character long"
+        "path is required and must be at least 1 character long",
       );
     }
     if (!json.redirect_uri || json.redirect_uri.length < 1) {
       throw new TypeError(
-        "redirect_uri is required and must be at least 1 character long"
+        "redirect_uri is required and must be at least 1 character long",
       );
     }
 

--- a/capabilities/lib/authservice/secretBuilder.test.ts
+++ b/capabilities/lib/authservice/secretBuilder.test.ts
@@ -1,13 +1,13 @@
 import anyTest, { TestFn } from "ava";
 
 import { AuthServiceSecretBuilder } from "./secretBuilder";
-import { V1Secret } from "@kubernetes/client-node";
+import { k8s } from "pepr";
 import { K8sAPI } from "../kubernetes-api";
 import { AuthserviceConfig } from "./secretConfig";
 
 const test = anyTest as TestFn<{
   authServiceSecretBuilder: AuthServiceSecretBuilder;
-  testSecret: V1Secret;
+  testSecret: k8s.V1Secret;
 }>;
 
 test.beforeEach(t => {
@@ -67,7 +67,7 @@ test("AuthServiceSecretBuilder should handle adding a secret correctly", async t
 });
 
 test("AuthServiceSecretBuilder should handle deleting a secret correctly", async t => {
-  const deletedSecret: V1Secret = {
+  const deletedSecret: k8s.V1Secret = {
     metadata: {
       namespace: "default",
       name: "foo",

--- a/capabilities/lib/authservice/secretBuilder.test.ts
+++ b/capabilities/lib/authservice/secretBuilder.test.ts
@@ -35,7 +35,15 @@ test.beforeEach(t => {
 
   // mock authservice config
   secretBuilder.getAuthServiceConfig = () => {
-    return Promise.resolve(new AuthserviceConfig({ chains: [] }));
+    return Promise.resolve(
+      new AuthserviceConfig({
+        chains: [],
+        listen_address: "0.0.0.0",
+        listen_port: 8080,
+        log_level: "info",
+        threads: 4,
+      }),
+    );
   };
 
   t.context = {

--- a/capabilities/lib/authservice/secretBuilder.test.ts
+++ b/capabilities/lib/authservice/secretBuilder.test.ts
@@ -60,7 +60,7 @@ test.beforeEach(t => {
 test("AuthServiceSecretBuilder should handle adding a secret correctly", async t => {
   const secrets = await t.context.authServiceSecretBuilder.buildSecretList(
     t.context.testSecret,
-    false
+    false,
   );
 
   t.is(secrets.length, 3);
@@ -76,7 +76,7 @@ test("AuthServiceSecretBuilder should handle deleting a secret correctly", async
 
   const secrets = await t.context.authServiceSecretBuilder.buildSecretList(
     deletedSecret,
-    true
+    true,
   );
 
   t.is(secrets.length, 1);
@@ -90,7 +90,7 @@ test("AuthServiceSecretBuilder should handle sorting secrets correctly", async t
         name: "foo",
       },
     },
-    false
+    false,
   );
 
   t.is(secrets.length, 3);

--- a/capabilities/lib/authservice/secretBuilder.ts
+++ b/capabilities/lib/authservice/secretBuilder.ts
@@ -57,9 +57,8 @@ export class AuthServiceSecretBuilder {
     isDelete: boolean,
     labelSelector = "pepr.dev/keycloak=oidcconfig",
   ): Promise<k8s.V1Secret[]> {
-    let missionSecrets = await this.k8sApi.getSecretsByLabelSelector(
-      labelSelector,
-    );
+    let missionSecrets =
+      await this.k8sApi.getSecretsByLabelSelector(labelSelector);
 
     function isEqual(s: k8s.V1Secret) {
       return (secret: k8s.V1Secret) =>

--- a/capabilities/lib/authservice/secretBuilder.ts
+++ b/capabilities/lib/authservice/secretBuilder.ts
@@ -1,12 +1,11 @@
-import { Log } from "pepr";
+import { Log, k8s } from "pepr";
 import { K8sAPI } from "../kubernetes-api";
 import { AuthserviceConfig } from "./secretConfig";
-import { V1Secret } from "@kubernetes/client-node";
 import { createHash } from "crypto";
 import { ascend, path, reject, sortWith } from "ramda";
 
 interface UpdateEvent {
-  secret: V1Secret;
+  secret: k8s.V1Secret;
   isDelete: boolean;
 }
 
@@ -21,7 +20,7 @@ export class AuthServiceSecretBuilder {
     this.k8sApi = k8sApi;
   }
 
-  private decodeBase64(secret: V1Secret, key: string): string {
+  private decodeBase64(secret: k8s.V1Secret, key: string): string {
     if (!secret.data) {
       throw new Error("Data is missing in secret");
     }
@@ -31,19 +30,19 @@ export class AuthServiceSecretBuilder {
     return Buffer.from(secret.data[key], "base64").toString("utf-8");
   }
 
-  private sortSecrets(secrets: V1Secret[]): V1Secret[] {
+  private sortSecrets(secrets: k8s.V1Secret[]): k8s.V1Secret[] {
     return sortWith([
       ascend(path(["metadata", "name"])),
       ascend(path(["metadata", "namespace"])),
     ])(secrets);
   }
 
-  secretToAuthServiceConfig(secret: V1Secret): AuthserviceConfig {
+  secretToAuthServiceConfig(secret: k8s.V1Secret): AuthserviceConfig {
     const secretData = this.k8sApi.getSecretValues(secret, [
       this.authServiceConfigFileName,
     ]);
     return new AuthserviceConfig(
-      JSON.parse(secretData[this.authServiceConfigFileName])
+      JSON.parse(secretData[this.authServiceConfigFileName]),
     );
   }
 
@@ -54,16 +53,16 @@ export class AuthServiceSecretBuilder {
   }
 
   async buildSecretList(
-    updatedSecret: V1Secret,
+    updatedSecret: k8s.V1Secret,
     isDelete: boolean,
-    labelSelector = "pepr.dev/keycloak=oidcconfig"
-  ): Promise<V1Secret[]> {
+    labelSelector = "pepr.dev/keycloak=oidcconfig",
+  ): Promise<k8s.V1Secret[]> {
     let missionSecrets = await this.k8sApi.getSecretsByLabelSelector(
-      labelSelector
+      labelSelector,
     );
 
-    function isEqual(s: V1Secret) {
-      return (secret: V1Secret) =>
+    function isEqual(s: k8s.V1Secret) {
+      return (secret: k8s.V1Secret) =>
         secret.metadata.name === s?.metadata?.name &&
         secret.metadata.namespace === s?.metadata?.namespace;
     }
@@ -83,14 +82,14 @@ export class AuthServiceSecretBuilder {
   async getAuthServiceConfig(): Promise<AuthserviceConfig> {
     const response = await this.k8sApi.k8sApi.readNamespacedSecret(
       this.authServiceSecretName,
-      this.authServiceNamespace
+      this.authServiceNamespace,
     );
 
     return this.secretToAuthServiceConfig(response.body);
   }
 
   async buildAuthServiceConfig(
-    secrets: V1Secret[]
+    secrets: k8s.V1Secret[],
   ): Promise<AuthserviceConfig> {
     const authServiceConfig = await this.getAuthServiceConfig();
 
@@ -116,7 +115,7 @@ export class AuthServiceSecretBuilder {
           hostname: "localhost.localhost",
           redirect_uri: "https://localhost.localhost",
           secret: "placeholderSecret",
-        })
+        }),
       );
     }
 
@@ -132,7 +131,7 @@ export class AuthServiceSecretBuilder {
       this.authServiceNamespace,
       {
         [this.authServiceConfigFileName]: config,
-      }
+      },
     );
 
     if (didItWork) {
@@ -140,12 +139,12 @@ export class AuthServiceSecretBuilder {
       await this.k8sApi.checksumDeployment(
         "authservice",
         "authservice",
-        configHash
+        configHash,
       );
     } else {
       Log.error(
         "Patching AuthService Secret failed (out of sync)",
-        "updateAuthServiceSecret"
+        "updateAuthServiceSecret",
       );
     }
   }

--- a/capabilities/lib/authservice/secretConfig.test.ts
+++ b/capabilities/lib/authservice/secretConfig.test.ts
@@ -31,15 +31,13 @@ test("AuthserviceConfig should handle input correctly", t => {
   t.is(oidcConfig.client_secret, chainInput.secret);
   t.is(oidcConfig.cookie_name_prefix, chainInput.name);
 
-  const json = {
-    chains: [filterChain.toObject()],
+  const authserviceConfig = new AuthserviceConfig({
+    chains: [filterChain],
     listen_address: "localhost",
     listen_port: 8080,
     log_level: "debug",
     threads: 1,
-  };
-
-  const authserviceConfig = new AuthserviceConfig(json);
+  });
 
   // Check AuthserviceConfig properties
   t.is(authserviceConfig.chains.length, 1);

--- a/capabilities/lib/authservice/secretConfig.ts
+++ b/capabilities/lib/authservice/secretConfig.ts
@@ -191,10 +191,7 @@ export class AuthserviceConfig {
     if (json.default_oidc_config !== undefined) {
       this.default_oidc_config = new OIDCConfig(json.default_oidc_config);
     }
-
-    if (json.allow_unmatched_requests !== undefined) {
-      this.allow_unmatched_requests = json.allow_unmatched_requests;
-    }
+    this.allow_unmatched_requests = json?.allow_unmatched_requests;
   }
 
   static createSingleChain(input: ChainInput): FilterChain {

--- a/capabilities/lib/authservice/secretConfig.ts
+++ b/capabilities/lib/authservice/secretConfig.ts
@@ -36,10 +36,10 @@ export class TriggerRule {
 
   constructor(json: any) {
     this.excluded_paths = json.excluded_paths.map(
-      (path: any) => new StringMatch(path)
+      (path: any) => new StringMatch(path),
     );
     this.included_paths = json.included_paths.map(
-      (path: any) => new StringMatch(path)
+      (path: any) => new StringMatch(path),
     );
   }
   toObject(): Record<string, any> {
@@ -162,7 +162,7 @@ export class AuthserviceConfig {
 
     if (json.trigger_rules !== undefined) {
       this.trigger_rules = json.trigger_rules.map(
-        (rule: any) => new TriggerRule(rule)
+        (rule: any) => new TriggerRule(rule),
       );
     }
 

--- a/capabilities/lib/authservice/secretConfig.ts
+++ b/capabilities/lib/authservice/secretConfig.ts
@@ -20,7 +20,7 @@ export class StringMatch {
       this.regex = json.regex;
     }
   }
-  toObject(): Record<string, any> {
+  toObject() {
     return {
       exact: this.exact,
       prefix: this.prefix,
@@ -42,7 +42,7 @@ export class TriggerRule {
       (path: any) => new StringMatch(path),
     );
   }
-  toObject(): Record<string, any> {
+  toObject() {
     return {
       excluded_paths: this.excluded_paths.map(path => path.toObject()),
       included_paths: this.included_paths.map(path => path.toObject()),
@@ -71,7 +71,7 @@ export class Match {
       throw new TypeError("prefix and equality cannot both be set");
     }
   }
-  toObject(): Record<string, any> {
+  toObject() {
     return {
       header: this.header,
       prefix: this.prefix,
@@ -99,7 +99,7 @@ export class Filter {
     }
   }
 
-  toObject(): Record<string, any> {
+  toObject() {
     const obj: Record<string, any> = {};
 
     if (this.oidc) {
@@ -126,7 +126,7 @@ export class FilterChain {
 
     this.filters = json.filters.map((filter: any) => new Filter(filter));
   }
-  toObject(): Record<string, any> {
+  toObject() {
     return {
       name: this.name,
       match: this.match?.toObject(),
@@ -199,7 +199,7 @@ export class AuthserviceConfig {
     });
   }
 
-  toObject(): Record<string, any> {
+  toObject() {
     return {
       chains: this.chains.map(chain => chain.toObject()),
       listen_address: this.listen_address,

--- a/capabilities/lib/kc-api.ts
+++ b/capabilities/lib/kc-api.ts
@@ -38,7 +38,7 @@ export class KcAPI {
     this.k8sApi = new K8sAPI();
     const responseSecret = await this.k8sApi.k8sApi.readNamespacedSecret(
       name,
-      namespace
+      namespace,
     );
     const existingSecret = responseSecret.body;
     const creds = this.k8sApi.getSecretValues(existingSecret, [
@@ -61,7 +61,7 @@ export class KcAPI {
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
         },
-      }
+      },
     );
 
     if (!response.ok) {
@@ -81,7 +81,7 @@ export class KcAPI {
         headers: {
           Authorization: `Bearer ${this.token}`,
         },
-      }
+      },
     );
 
     if (response.ok) {
@@ -102,7 +102,7 @@ export class KcAPI {
             Authorization: `Bearer ${this.token}`,
             "Content-Type": "application/json",
           },
-        }
+        },
       );
 
       if (!createResponse.ok) {
@@ -117,11 +117,11 @@ export class KcAPI {
 
   async GetOpenIdData(realmName: string): Promise<OpenIdData> {
     const response = await fetch<OpenIdData>(
-      `${this.keycloakBaseUrl}/realms/${realmName}/.well-known/openid-configuration`
+      `${this.keycloakBaseUrl}/realms/${realmName}/.well-known/openid-configuration`,
     );
     if (!response.ok) {
       throw new Error(
-        `failed to get openid-configuration for realm ${realmName}`
+        `failed to get openid-configuration for realm ${realmName}`,
       );
     }
     return response.data;
@@ -147,7 +147,7 @@ export class KcAPI {
 
   private async GetClientSecret(
     realmName: string,
-    clientId: string
+    clientId: string,
   ): Promise<string> {
     await this.connect();
     interface clientData {
@@ -162,7 +162,7 @@ export class KcAPI {
         headers: {
           Authorization: `Bearer ${this.token}`,
         },
-      }
+      },
     );
 
     if (!response.ok) {
@@ -189,7 +189,7 @@ export class KcAPI {
     realmName: string,
     clientName: string,
     clientId: string,
-    redirectUri: string
+    redirectUri: string,
   ): Promise<string> {
     await this.connect();
 
@@ -209,7 +209,7 @@ export class KcAPI {
     clientId: string,
     clientName: string,
     redirectUri: string,
-    realmName: string
+    realmName: string,
   ) {
     await this.connect();
 
@@ -228,7 +228,7 @@ export class KcAPI {
           Authorization: `Bearer ${this.token}`,
           "Content-Type": "application/json",
         },
-      }
+      },
     );
 
     if (!response.ok) {
@@ -245,11 +245,11 @@ export class KcAPI {
         headers: {
           Authorization: `Bearer ${this.token}`,
         },
-      }
+      },
     );
     if (!response.ok && response.status !== fetchStatus.NOT_FOUND) {
       throw new Error(
-        `Failed to delete client with clientId ${clientId}, ${response.status}`
+        `Failed to delete client with clientId ${clientId}, ${response.status}`,
       );
     }
   }

--- a/capabilities/lib/kubernetes-api.ts
+++ b/capabilities/lib/kubernetes-api.ts
@@ -1,5 +1,4 @@
-import { k8s } from "pepr";
-import { fetchStatus } from "pepr";
+import { fetchStatus, k8s } from "pepr";
 
 export class K8sAPI {
   k8sApi: k8s.CoreV1Api;

--- a/capabilities/lib/kubernetes-api.ts
+++ b/capabilities/lib/kubernetes-api.ts
@@ -77,7 +77,6 @@ export class K8sAPI {
     name: string,
     namespace: string,
     secretData: Record<string, string>,
-    ownerReferences: k8s.V1OwnerReference[],
     labels?: { [key: string]: string },
   ) {
     // Prepare the Secret object
@@ -88,7 +87,6 @@ export class K8sAPI {
         name: name,
         namespace: namespace,
         labels,
-        ownerReferences: ownerReferences,
       },
       data: {},
     };

--- a/capabilities/lib/kubernetes-api.ts
+++ b/capabilities/lib/kubernetes-api.ts
@@ -1,28 +1,20 @@
-import {
-  AppsV1Api,
-  CoreV1Api,
-  KubeConfig,
-  V1Secret,
-} from "@kubernetes/client-node";
-
 import { k8s } from "pepr";
-
 import { fetchStatus } from "pepr";
 
 export class K8sAPI {
-  k8sApi: CoreV1Api;
-  k8sAppsV1Api: AppsV1Api;
+  k8sApi: k8s.CoreV1Api;
+  k8sAppsV1Api: k8s.AppsV1Api;
 
   constructor() {
-    const kc = new KubeConfig();
+    const kc = new k8s.KubeConfig();
     kc.loadFromDefault();
-    this.k8sApi = kc.makeApiClient(CoreV1Api);
-    this.k8sAppsV1Api = kc.makeApiClient(AppsV1Api);
+    this.k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+    this.k8sAppsV1Api = kc.makeApiClient(k8s.AppsV1Api);
   }
 
   getSecretValues(
-    inputSecret: V1Secret,
-    keys: string[]
+    inputSecret: k8s.V1Secret,
+    keys: string[],
   ): { [key: string]: string } {
     const secret = inputSecret.data;
     const secretValues: { [key: string]: string } = {};
@@ -32,19 +24,19 @@ export class K8sAPI {
         if (secret[key]) {
           // Decode the base64 encoded secret value
           const decodedValue = Buffer.from(secret[key], "base64").toString(
-            "utf-8"
+            "utf-8",
           );
           secretValues[key] = decodedValue;
         } else {
           throw new Error(
-            `Could not find key '${key}' in the secret ${inputSecret.metadata?.name}`
+            `Could not find key '${key}' in the secret ${inputSecret.metadata?.name}`,
           );
         }
       });
       return secretValues;
     }
     throw new Error(
-      `Could not retrieve the secret ${inputSecret.metadata?.name}`
+      `Could not retrieve the secret ${inputSecret.metadata?.name}`,
     );
   }
 
@@ -66,16 +58,18 @@ export class K8sAPI {
       undefined,
       undefined,
       undefined,
-      { headers: { "content-type": "application/json-patch+json" } }
+      { headers: { "content-type": "application/json-patch+json" } },
     );
   }
 
-  async getSecretsByLabelSelector(labelSelector: string): Promise<V1Secret[]> {
+  async getSecretsByLabelSelector(
+    labelSelector: string,
+  ): Promise<k8s.V1Secret[]> {
     const secrets = await this.k8sApi.listSecretForAllNamespaces(
       null,
       null,
       null,
-      labelSelector
+      labelSelector,
     );
     return secrets?.body?.items || [];
   }
@@ -84,16 +78,18 @@ export class K8sAPI {
     name: string,
     namespace: string,
     secretData: Record<string, string>,
-    labels?: { [key: string]: string }
+    ownerReferences: k8s.V1OwnerReference[],
+    labels?: { [key: string]: string },
   ) {
     // Prepare the Secret object
-    const secret: V1Secret = {
+    const secret: k8s.V1Secret = {
       apiVersion: "v1",
       kind: "Secret",
       metadata: {
         name: name,
         namespace: namespace,
         labels,
+        ownerReferences: ownerReferences,
       },
       data: {},
     };
@@ -122,7 +118,7 @@ export class K8sAPI {
   async patchSecret(
     name: string,
     namespace: string,
-    secretData: Record<string, string>
+    secretData: Record<string, string>,
   ): Promise<boolean> {
     const data = {};
 
@@ -140,7 +136,7 @@ export class K8sAPI {
         undefined,
         undefined,
         undefined,
-        { headers: { "content-type": "application/merge-patch+json" } }
+        { headers: { "content-type": "application/merge-patch+json" } },
       );
       return true;
     } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.0.0-development",
       "license": "Apache-2.0",
       "dependencies": {
-        "pepr": "file:../shifting-sands/pepr/pepr-0.0.0-development.tgz"
+        "pepr": "^0.13.0"
       },
       "devDependencies": {
-        "ava": "5.3.x",
-        "typescript": "5.1.6"
+        "ava": "5.3.1",
+        "ts-node": "10.9.1"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -28,10 +28,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.15.tgz",
-      "integrity": "sha512-wlkQBWb79/jeEEoRmrxt/yhn5T1lU236OCNpnfRzaCJHZ/5gf82uYx1qmADTBWE0AR/v7FiozE1auk2riyQd3w==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.2.tgz",
+      "integrity": "sha512-tM8yLeYVe7pRyAu9VMi/Q7aunpLwD139EY1S99xbQkT4/q2qa6eA4ige/WJQYdJ8GBL1K33pPFhPfPdJ/WzT8Q==",
       "cpu": [
         "arm"
       ],
@@ -45,9 +57,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.15.tgz",
-      "integrity": "sha512-NI/gnWcMl2kXt1HJKOn2H69SYn4YNheKo6NZt1hyfKWdMbaGadxjZIkcj4Gjk/WPxnbFXs9/3HjGHaknCqjrww==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.2.tgz",
+      "integrity": "sha512-lsB65vAbe90I/Qe10OjkmrdxSX4UJDjosDgb8sZUKcg3oefEuW2OT2Vozz8ef7wrJbMcmhvCC+hciF8jY/uAkw==",
       "cpu": [
         "arm64"
       ],
@@ -61,9 +73,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.15.tgz",
-      "integrity": "sha512-FM9NQamSaEm/IZIhegF76aiLnng1kEsZl2eve/emxDeReVfRuRNmvT28l6hoFD9TsCxpK+i4v8LPpEj74T7yjA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.2.tgz",
+      "integrity": "sha512-qK/TpmHt2M/Hg82WXHRc/W/2SGo/l1thtDHZWqFq7oi24AjZ4O/CpPSu6ZuYKFkEgmZlFoa7CooAyYmuvnaG8w==",
       "cpu": [
         "x64"
       ],
@@ -77,9 +89,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.15.tgz",
-      "integrity": "sha512-XmrFwEOYauKte9QjS6hz60FpOCnw4zaPAb7XV7O4lx1r39XjJhTN7ZpXqJh4sN6q60zbP6QwAVVA8N/wUyBH/w==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.2.tgz",
+      "integrity": "sha512-Ora8JokrvrzEPEpZO18ZYXkH4asCdc1DLdcVy8TGf5eWtPO1Ie4WroEJzwI52ZGtpODy3+m0a2yEX9l+KUn0tA==",
       "cpu": [
         "arm64"
       ],
@@ -93,9 +105,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.15.tgz",
-      "integrity": "sha512-bMqBmpw1e//7Fh5GLetSZaeo9zSC4/CMtrVFdj+bqKPGJuKyfNJ5Nf2m3LknKZTS+Q4oyPiON+v3eaJ59sLB5A==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.2.tgz",
+      "integrity": "sha512-tP+B5UuIbbFMj2hQaUr6EALlHOIOmlLM2FK7jeFBobPy2ERdohI4Ka6ZFjZ1ZYsrHE/hZimGuU90jusRE0pwDw==",
       "cpu": [
         "x64"
       ],
@@ -109,9 +121,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.15.tgz",
-      "integrity": "sha512-LoTK5N3bOmNI9zVLCeTgnk5Rk0WdUTrr9dyDAQGVMrNTh9EAPuNwSTCgaKOKiDpverOa0htPcO9NwslSE5xuLA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.2.tgz",
+      "integrity": "sha512-YbPY2kc0acfzL1VPVK6EnAlig4f+l8xmq36OZkU0jzBVHcOTyQDhnKQaLzZudNJQyymd9OqQezeaBgkTGdTGeQ==",
       "cpu": [
         "arm64"
       ],
@@ -125,9 +137,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.15.tgz",
-      "integrity": "sha512-62jX5n30VzgrjAjOk5orYeHFq6sqjvsIj1QesXvn5OZtdt5Gdj0vUNJy9NIpjfdNdqr76jjtzBJKf+h2uzYuTQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.2.tgz",
+      "integrity": "sha512-nSO5uZT2clM6hosjWHAsS15hLrwCvIWx+b2e3lZ3MwbYSaXwvfO528OF+dLjas1g3bZonciivI8qKR/Hm7IWGw==",
       "cpu": [
         "x64"
       ],
@@ -141,9 +153,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.15.tgz",
-      "integrity": "sha512-dT4URUv6ir45ZkBqhwZwyFV6cH61k8MttIwhThp2BGiVtagYvCToF+Bggyx2VI57RG4Fbt21f9TmXaYx0DeUJg==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.2.tgz",
+      "integrity": "sha512-Odalh8hICg7SOD7XCj0YLpYCEc+6mkoq63UnExDCiRA2wXEmGlK5JVrW50vZR9Qz4qkvqnHcpH+OFEggO3PgTg==",
       "cpu": [
         "arm"
       ],
@@ -157,9 +169,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.15.tgz",
-      "integrity": "sha512-BWncQeuWDgYv0jTNzJjaNgleduV4tMbQjmk/zpPh/lUdMcNEAxy+jvneDJ6RJkrqloG7tB9S9rCrtfk/kuplsQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.2.tgz",
+      "integrity": "sha512-ig2P7GeG//zWlU0AggA3pV1h5gdix0MA3wgB+NsnBXViwiGgY77fuN9Wr5uoCrs2YzaYfogXgsWZbm+HGr09xg==",
       "cpu": [
         "arm64"
       ],
@@ -173,9 +185,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.15.tgz",
-      "integrity": "sha512-JPXORvgHRHITqfms1dWT/GbEY89u848dC08o0yK3fNskhp0t2TuNUnsrrSgOdH28ceb1hJuwyr8R/1RnyPwocw==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.2.tgz",
+      "integrity": "sha512-mLfp0ziRPOLSTek0Gd9T5B8AtzKAkoZE70fneiiyPlSnUKKI4lp+mGEnQXcQEHLJAcIYDPSyBvsUbKUG2ri/XQ==",
       "cpu": [
         "ia32"
       ],
@@ -189,9 +201,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.15.tgz",
-      "integrity": "sha512-kArPI0DopjJCEplsVj/H+2Qgzz7vdFSacHNsgoAKpPS6W/Ndh8Oe24HRDQ5QCu4jHgN6XOtfFfLpRx3TXv/mEg==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.2.tgz",
+      "integrity": "sha512-hn28+JNDTxxCpnYjdDYVMNTR3SKavyLlCHHkufHV91fkewpIyQchS1d8wSbmXhs1fiYDpNww8KTFlJ1dHsxeSw==",
       "cpu": [
         "loong64"
       ],
@@ -205,9 +217,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.15.tgz",
-      "integrity": "sha512-b/tmngUfO02E00c1XnNTw/0DmloKjb6XQeqxaYuzGwHe0fHVgx5/D6CWi+XH1DvkszjBUkK9BX7n1ARTOst59w==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.2.tgz",
+      "integrity": "sha512-KbXaC0Sejt7vD2fEgPoIKb6nxkfYW9OmFUK9XQE4//PvGIxNIfPk1NmlHmMg6f25x57rpmEFrn1OotASYIAaTg==",
       "cpu": [
         "mips64el"
       ],
@@ -221,9 +233,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.15.tgz",
-      "integrity": "sha512-KXPY69MWw79QJkyvUYb2ex/OgnN/8N/Aw5UDPlgoRtoEfcBqfeLodPr42UojV3NdkoO4u10NXQdamWm1YEzSKw==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.2.tgz",
+      "integrity": "sha512-dJ0kE8KTqbiHtA3Fc/zn7lCd7pqVr4JcT0JqOnbj4LLzYnp+7h8Qi4yjfq42ZlHfhOCM42rBh0EwHYLL6LEzcw==",
       "cpu": [
         "ppc64"
       ],
@@ -237,9 +249,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.15.tgz",
-      "integrity": "sha512-komK3NEAeeGRnvFEjX1SfVg6EmkfIi5aKzevdvJqMydYr9N+pRQK0PGJXk+bhoPZwOUgLO4l99FZmLGk/L1jWg==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.2.tgz",
+      "integrity": "sha512-7Z/jKNFufZ/bbu4INqqCN6DDlrmOTmdw6D0gH+6Y7auok2r02Ur661qPuXidPOJ+FSgbEeQnnAGgsVynfLuOEw==",
       "cpu": [
         "riscv64"
       ],
@@ -253,9 +265,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.15.tgz",
-      "integrity": "sha512-632T5Ts6gQ2WiMLWRRyeflPAm44u2E/s/TJvn+BP6M5mnHSk93cieaypj3VSMYO2ePTCRqAFXtuYi1yv8uZJNA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.2.tgz",
+      "integrity": "sha512-U+RinR6aXXABFCcAY4gSlv4CL1oOVvSSCdseQmGO66H+XyuQGZIUdhG56SZaDJQcLmrSfRmx5XZOWyCJPRqS7g==",
       "cpu": [
         "s390x"
       ],
@@ -269,9 +281,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.15.tgz",
-      "integrity": "sha512-MsHtX0NgvRHsoOtYkuxyk4Vkmvk3PLRWfA4okK7c+6dT0Fu4SUqXAr9y4Q3d8vUf1VWWb6YutpL4XNe400iQ1g==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.2.tgz",
+      "integrity": "sha512-oxzHTEv6VPm3XXNaHPyUTTte+3wGv7qVQtqaZCrgstI16gCuhNOtBXLEBkBREP57YTd68P0VgDgG73jSD8bwXQ==",
       "cpu": [
         "x64"
       ],
@@ -285,9 +297,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.15.tgz",
-      "integrity": "sha512-djST6s+jQiwxMIVQ5rlt24JFIAr4uwUnzceuFL7BQT4CbrRtqBPueS4GjXSiIpmwVri1Icj/9pFRJ7/aScvT+A==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.2.tgz",
+      "integrity": "sha512-WNa5zZk1XpTTwMDompZmvQLHszDDDN7lYjEHCUmAGB83Bgs20EMs7ICD+oKeT6xt4phV4NDdSi/8OfjPbSbZfQ==",
       "cpu": [
         "x64"
       ],
@@ -301,9 +313,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.15.tgz",
-      "integrity": "sha512-naeRhUIvhsgeounjkF5mvrNAVMGAm6EJWiabskeE5yOeBbLp7T89tAEw0j5Jm/CZAwyLe3c67zyCWH6fsBLCpw==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.2.tgz",
+      "integrity": "sha512-S6kI1aT3S++Dedb7vxIuUOb3oAxqxk2Rh5rOXOTYnzN8JzW1VzBd+IqPiSpgitu45042SYD3HCoEyhLKQcDFDw==",
       "cpu": [
         "x64"
       ],
@@ -317,9 +329,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.15.tgz",
-      "integrity": "sha512-qkT2+WxyKbNIKV1AEhI8QiSIgTHMcRctzSaa/I3kVgMS5dl3fOeoqkb7pW76KwxHoriImhx7Mg3TwN/auMDsyQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.2.tgz",
+      "integrity": "sha512-VXSSMsmb+Z8LbsQGcBMiM+fYObDNRm8p7tkUDMPG/g4fhFX5DEFmjxIEa3N8Zr96SjsJ1woAhF0DUnS3MF3ARw==",
       "cpu": [
         "x64"
       ],
@@ -333,9 +345,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.15.tgz",
-      "integrity": "sha512-HC4/feP+pB2Vb+cMPUjAnFyERs+HJN7E6KaeBlFdBv799MhD+aPJlfi/yk36SED58J9TPwI8MAcVpJgej4ud0A==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.2.tgz",
+      "integrity": "sha512-5NayUlSAyb5PQYFAU9x3bHdsqB88RC3aM9lKDAz4X1mo/EchMIT1Q+pSeBXNgkfNmRecLXA0O8xP+x8V+g/LKg==",
       "cpu": [
         "arm64"
       ],
@@ -349,9 +361,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.15.tgz",
-      "integrity": "sha512-ovjwoRXI+gf52EVF60u9sSDj7myPixPxqzD5CmkEUmvs+W9Xd0iqISVBQn8xcx4ciIaIVlWCuTbYDOXOnOL44Q==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.2.tgz",
+      "integrity": "sha512-47gL/ek1v36iN0wL9L4Q2MFdujR0poLZMJwhO2/N3gA89jgHp4MR8DKCmwYtGNksbfJb9JoTtbkoe6sDhg2QTA==",
       "cpu": [
         "ia32"
       ],
@@ -365,9 +377,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.15.tgz",
-      "integrity": "sha512-imUxH9a3WJARyAvrG7srLyiK73XdX83NXQkjKvQ+7vPh3ZxoLrzvPkQKKw2DwZ+RV2ZB6vBfNHP8XScAmQC3aA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.2.tgz",
+      "integrity": "sha512-tcuhV7ncXBqbt/Ybf0IyrMcwVOAPDckMK9rXNHtF17UTK18OKLpg08glminN06pt2WCoALhXdLfSPbVvK/6fxw==",
       "cpu": [
         "x64"
       ],
@@ -396,9 +408,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.7.0.tgz",
-      "integrity": "sha512-+HencqxU7CFJnQb7IKtuNBqS6Yx3Tz4kOL8BJXo+JyeiBm5MEX6pO8onXDkjrkCRlfYXS1Axro15ZjVFe9YgsA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.0.tgz",
+      "integrity": "sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==",
       "peer": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -428,9 +440,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
-      "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.48.0.tgz",
+      "integrity": "sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==",
       "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -469,6 +481,31 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "peer": true
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@kubernetes/client-node": {
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.18.1.tgz",
@@ -494,6 +531,11 @@
       "optionalDependencies": {
         "openid-client": "^5.3.0"
       }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/@types/node": {
+      "version": "18.17.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.12.tgz",
+      "integrity": "sha512-d6xjC9fJ/nSnfDeU0AMDsaJyb1iHsqCSOdi84w4u+SlN/UgQdY5tRhpMzaFYsI4mnpvgTivEaQd0yOUhAtOnEQ=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -527,6 +569,30 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "node_modules/@types/caseless": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
@@ -544,9 +610,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "18.17.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.7.tgz",
-      "integrity": "sha512-WJj/p/cIg6zUsxv1n2leZHpvn8hr9TYuLQxAZxZcK/7+5t5ukmJGelOLGOy3L1MLhAO/sapTJGd1V7kvoIuzUg=="
+      "version": "20.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
+      "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA=="
     },
     "node_modules/@types/request": {
       "version": "2.48.8",
@@ -560,9 +626,9 @@
       }
     },
     "node_modules/@types/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==",
       "peer": true
     },
     "node_modules/@types/tough-cookie": {
@@ -579,21 +645,20 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.1.0.tgz",
-      "integrity": "sha512-qg7Bm5TyP/I7iilGyp6DRqqkt8na00lI6HbjWZObgk3FFSzH5ypRwAHXJhJkwiRtTcfn+xYQIMOR5kJgpo6upw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.0.tgz",
+      "integrity": "sha512-62o2Hmc7Gs3p8SLfbXcipjWAa6qk2wZGChXG2JbBtYpwSRmti/9KHLqfbLs9uDigOexG+3PaQ9G2g3201FWLKg==",
       "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.1.0",
-        "@typescript-eslint/type-utils": "6.1.0",
-        "@typescript-eslint/utils": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0",
+        "@typescript-eslint/scope-manager": "6.4.0",
+        "@typescript-eslint/type-utils": "6.4.0",
+        "@typescript-eslint/utils": "6.4.0",
+        "@typescript-eslint/visitor-keys": "6.4.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
         "natural-compare": "^1.4.0",
-        "natural-compare-lite": "^1.4.0",
         "semver": "^7.5.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -615,15 +680,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.1.0.tgz",
-      "integrity": "sha512-hIzCPvX4vDs4qL07SYzyomamcs2/tQYXg5DtdAfj35AyJ5PIUqhsLf4YrEIFzZcND7R2E8tpQIZKayxg8/6Wbw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.0.tgz",
+      "integrity": "sha512-I1Ah1irl033uxjxO9Xql7+biL3YD7w9IU8zF+xlzD/YxY6a4b7DYA08PXUUCbm2sEljwJF6ERFy2kTGAGcNilg==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.1.0",
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/typescript-estree": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0",
+        "@typescript-eslint/scope-manager": "6.4.0",
+        "@typescript-eslint/types": "6.4.0",
+        "@typescript-eslint/typescript-estree": "6.4.0",
+        "@typescript-eslint/visitor-keys": "6.4.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -643,13 +708,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.1.0.tgz",
-      "integrity": "sha512-AxjgxDn27hgPpe2rQe19k0tXw84YCOsjDJ2r61cIebq1t+AIxbgiXKvD4999Wk49GVaAcdJ/d49FYel+Pp3jjw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.0.tgz",
+      "integrity": "sha512-TUS7vaKkPWDVvl7GDNHFQMsMruD+zhkd3SdVW0d7b+7Zo+bd/hXJQ8nsiUZMi1jloWo6c9qt3B7Sqo+flC1nig==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0"
+        "@typescript-eslint/types": "6.4.0",
+        "@typescript-eslint/visitor-keys": "6.4.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -660,13 +725,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.1.0.tgz",
-      "integrity": "sha512-kFXBx6QWS1ZZ5Ni89TyT1X9Ag6RXVIVhqDs0vZE/jUeWlBv/ixq2diua6G7ece6+fXw3TvNRxP77/5mOMusx2w==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.4.0.tgz",
+      "integrity": "sha512-TvqrUFFyGY0cX3WgDHcdl2/mMCWCDv/0thTtx/ODMY1QhEiyFtv/OlLaNIiYLwRpAxAtOLOY9SUf1H3Q3dlwAg==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.1.0",
-        "@typescript-eslint/utils": "6.1.0",
+        "@typescript-eslint/typescript-estree": "6.4.0",
+        "@typescript-eslint/utils": "6.4.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -687,9 +752,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.1.0.tgz",
-      "integrity": "sha512-+Gfd5NHCpDoHDOaU/yIF3WWRI2PcBRKKpP91ZcVbL0t5tQpqYWBs3z/GGhvU+EV1D0262g9XCnyqQh19prU0JQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.0.tgz",
+      "integrity": "sha512-+FV9kVFrS7w78YtzkIsNSoYsnOtrYVnKWSTVXoL1761CsCRv5wpDOINgsXpxD67YCLZtVQekDDyaxfjVWUJmmg==",
       "peer": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -700,13 +765,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.1.0.tgz",
-      "integrity": "sha512-nUKAPWOaP/tQjU1IQw9sOPCDavs/iU5iYLiY/6u7gxS7oKQoi4aUxXS1nrrVGTyBBaGesjkcwwHkbkiD5eBvcg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.0.tgz",
+      "integrity": "sha512-iDPJArf/K2sxvjOR6skeUCNgHR/tCQXBsa+ee1/clRKr3olZjZ/dSkXPZjG6YkPtnW6p5D1egeEPMCW6Gn4yLA==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/visitor-keys": "6.1.0",
+        "@typescript-eslint/types": "6.4.0",
+        "@typescript-eslint/visitor-keys": "6.4.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -727,17 +792,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.1.0.tgz",
-      "integrity": "sha512-wp652EogZlKmQoMS5hAvWqRKplXvkuOnNzZSE0PVvsKjpexd/XznRVHAtrfHFYmqaJz0DFkjlDsGYC9OXw+OhQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.0.tgz",
+      "integrity": "sha512-BvvwryBQpECPGo8PwF/y/q+yacg8Hn/2XS+DqL/oRsOPK+RPt29h5Ui5dqOKHDlbXrAeHUTnyG3wZA0KTDxRZw==",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.1.0",
-        "@typescript-eslint/types": "6.1.0",
-        "@typescript-eslint/typescript-estree": "6.1.0",
+        "@typescript-eslint/scope-manager": "6.4.0",
+        "@typescript-eslint/types": "6.4.0",
+        "@typescript-eslint/typescript-estree": "6.4.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -752,12 +817,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.1.0.tgz",
-      "integrity": "sha512-yQeh+EXhquh119Eis4k0kYhj9vmFzNpbhM3LftWQVwqVjipCkwHBQOZutcYW+JVkjtTG9k8nrZU1UoNedPDd1A==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.0.tgz",
+      "integrity": "sha512-yJSfyT+uJm+JRDWYRYdCm2i+pmvXJSMtPR9Cq5/XQs4QIgNoLcoRtDdzsLbLsFM/c6um6ohQkg/MLxWvoIndJA==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/types": "6.4.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -766,6 +831,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/accepts": {
@@ -877,6 +953,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -946,6 +1028,14 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/ava": {
       "version": "5.3.1",
@@ -1061,6 +1151,25 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1143,6 +1252,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/byline": {
@@ -1420,6 +1552,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1516,6 +1653,12 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1563,6 +1706,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -1615,6 +1766,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dir-glob": {
@@ -1686,10 +1846,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/esbuild": {
-      "version": "0.18.15",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.15.tgz",
-      "integrity": "sha512-3WOOLhrvuTGPRzQPU6waSDWrDTnQriia72McWcn6UCi43GhCHrXH4S59hKMeez+IITmdUuUyvbU9JIp+t3xlPQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.2.tgz",
+      "integrity": "sha512-G6hPax8UbFakEj3hWO0Vs52LQ8k3lnBhxZWomUJDxfz3rZTLqF5k/FCzuNdLx2RbpBiQQF9H9onlDDH1lZsnjg==",
       "hasInstallScript": true,
       "peer": true,
       "bin": {
@@ -1699,28 +1867,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.15",
-        "@esbuild/android-arm64": "0.18.15",
-        "@esbuild/android-x64": "0.18.15",
-        "@esbuild/darwin-arm64": "0.18.15",
-        "@esbuild/darwin-x64": "0.18.15",
-        "@esbuild/freebsd-arm64": "0.18.15",
-        "@esbuild/freebsd-x64": "0.18.15",
-        "@esbuild/linux-arm": "0.18.15",
-        "@esbuild/linux-arm64": "0.18.15",
-        "@esbuild/linux-ia32": "0.18.15",
-        "@esbuild/linux-loong64": "0.18.15",
-        "@esbuild/linux-mips64el": "0.18.15",
-        "@esbuild/linux-ppc64": "0.18.15",
-        "@esbuild/linux-riscv64": "0.18.15",
-        "@esbuild/linux-s390x": "0.18.15",
-        "@esbuild/linux-x64": "0.18.15",
-        "@esbuild/netbsd-x64": "0.18.15",
-        "@esbuild/openbsd-x64": "0.18.15",
-        "@esbuild/sunos-x64": "0.18.15",
-        "@esbuild/win32-arm64": "0.18.15",
-        "@esbuild/win32-ia32": "0.18.15",
-        "@esbuild/win32-x64": "0.18.15"
+        "@esbuild/android-arm": "0.19.2",
+        "@esbuild/android-arm64": "0.19.2",
+        "@esbuild/android-x64": "0.19.2",
+        "@esbuild/darwin-arm64": "0.19.2",
+        "@esbuild/darwin-x64": "0.19.2",
+        "@esbuild/freebsd-arm64": "0.19.2",
+        "@esbuild/freebsd-x64": "0.19.2",
+        "@esbuild/linux-arm": "0.19.2",
+        "@esbuild/linux-arm64": "0.19.2",
+        "@esbuild/linux-ia32": "0.19.2",
+        "@esbuild/linux-loong64": "0.19.2",
+        "@esbuild/linux-mips64el": "0.19.2",
+        "@esbuild/linux-ppc64": "0.19.2",
+        "@esbuild/linux-riscv64": "0.19.2",
+        "@esbuild/linux-s390x": "0.19.2",
+        "@esbuild/linux-x64": "0.19.2",
+        "@esbuild/netbsd-x64": "0.19.2",
+        "@esbuild/openbsd-x64": "0.19.2",
+        "@esbuild/sunos-x64": "0.19.2",
+        "@esbuild/win32-arm64": "0.19.2",
+        "@esbuild/win32-ia32": "0.19.2",
+        "@esbuild/win32-x64": "0.19.2"
       }
     },
     "node_modules/escalade": {
@@ -1750,27 +1918,27 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
-      "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.47.0.tgz",
+      "integrity": "sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.1.0",
-        "@eslint/js": "8.44.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "^8.47.0",
         "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.1",
-        "espree": "^9.6.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -1974,6 +2142,22 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/express": {
       "version": "4.18.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
@@ -2041,6 +2225,11 @@
         "node >=0.6.0"
       ]
     },
+    "node_modules/fast-copy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
+      "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2082,6 +2271,19 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "peer": true
+    },
+    "node_modules/fast-redact": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.3.0.tgz",
+      "integrity": "sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -2189,16 +2391,17 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.0.tgz",
+      "integrity": "sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==",
       "peer": true,
       "dependencies": {
-        "flatted": "^3.1.0",
+        "flatted": "^3.2.7",
+        "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/flatted": {
@@ -2322,19 +2525,18 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       },
       "engines": {
-        "node": "*"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2349,6 +2551,25 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/globals": {
@@ -2455,6 +2676,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/help-me": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
+      "integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
+      "dependencies": {
+        "glob": "^8.0.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/help-me/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -2499,6 +2742,25 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ignore": {
       "version": "5.2.4",
@@ -2710,6 +2972,14 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -2734,6 +3004,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "peer": true
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
@@ -2776,6 +3052,15 @@
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
+      "peer": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kleur": {
@@ -2849,6 +3134,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/map-age-cleaner": {
       "version": "0.1.3",
@@ -3011,6 +3302,14 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
@@ -3064,12 +3363,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "peer": true
     },
-    "node_modules/natural-compare-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-      "peer": true
-    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -3079,9 +3372,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -3157,6 +3450,11 @@
       "engines": {
         "node": "^10.13.0 || >=12.0.0"
       }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+      "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -3371,16 +3669,17 @@
       }
     },
     "node_modules/pepr": {
-      "version": "0.0.0-development",
-      "resolved": "file:../shifting-sands/pepr/pepr-0.0.0-development.tgz",
-      "integrity": "sha512-ytVFWxnqMRuVAUtBdSq26Is9BVs/ZyeEClf8RDyYj7TsnCogUXdEXNpXBbiRxeMnJODyWS/VlSPA2Y/gpct/Ag==",
-      "license": "Apache-2.0",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/pepr/-/pepr-0.13.0.tgz",
+      "integrity": "sha512-5v7Iz6L0X0Dobjwozbbd7yASC2peZv5Yhm22oPgRSPkcL6KnYwwby6yB3fbreGHlBEjM5Qinq5FoHhzbbQoATg==",
       "dependencies": {
         "@kubernetes/client-node": "0.18.1",
         "express": "4.18.2",
         "fast-json-patch": "3.1.1",
         "http-status-codes": "2.2.0",
-        "node-fetch": "2.6.12",
+        "node-fetch": "2.7.0",
+        "pino": "8.15.0",
+        "pino-pretty": "10.2.0",
         "prom-client": "14.2.0",
         "ramda": "0.29.0"
       },
@@ -3391,13 +3690,13 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "6.1.0",
-        "@typescript-eslint/parser": "6.1.0",
+        "@typescript-eslint/eslint-plugin": "6.4.0",
+        "@typescript-eslint/parser": "6.4.0",
         "commander": "11.0.0",
-        "esbuild": "0.18.15",
-        "eslint": "8.45.0",
+        "esbuild": "0.19.2",
+        "eslint": "8.47.0",
         "node-forge": "1.3.1",
-        "prettier": "3.0.0",
+        "prettier": "3.0.1",
         "prompts": "2.4.2",
         "typescript": "5.1.6",
         "uuid": "9.0.0"
@@ -3418,6 +3717,65 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/pino": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.15.0.tgz",
+      "integrity": "sha512-olUADJByk4twxccmAxb1RiGKOSvddHugCV3wkqjyv+3Sooa2KLrmXrKEWOKi0XPCLasRR5jBXxioE1jxUa4KzQ==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.0.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^2.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.1.0",
+        "thread-stream": "^2.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.2.0.tgz",
+      "integrity": "sha512-tRvpyEmGtc2D+Lr3FulIZ+R1baggQ4S3xD2Ar93KixFEDx6SEAUP3W5aYuEw1C73d6ROrNcB2IXLteW8itlwhA==",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^4.0.1",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
     },
     "node_modules/pkg-conf": {
       "version": "4.0.0",
@@ -3542,9 +3900,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
+      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
       "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -3570,6 +3928,19 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-warning": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
+      "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg=="
     },
     "node_modules/prom-client": {
       "version": "14.2.0",
@@ -3612,6 +3983,15 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -3653,6 +4033,11 @@
         }
       ]
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+    },
     "node_modules/ramda": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
@@ -3684,6 +4069,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3694,6 +4094,14 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/request": {
@@ -3824,6 +4232,25 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3865,10 +4292,23 @@
         }
       ]
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="
     },
     "node_modules/semver": {
       "version": "7.5.4",
@@ -4043,6 +4483,22 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.3.0.tgz",
+      "integrity": "sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -4110,6 +4566,14 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -4146,7 +4610,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -4242,6 +4705,14 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "peer": true
     },
+    "node_modules/thread-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.4.0.tgz",
+      "integrity": "sha512-xZYtOtmnA63zj04Q+F9bdEay5r47bvpo1CaNqsKi7TpoJHcotUez8Fkfo2RJWpW91lnnaApdpRbVwCWsy+ifcw==",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/time-zone": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
@@ -4318,6 +4789,49 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -4379,6 +4893,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4408,6 +4923,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -4424,6 +4944,12 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -4693,6 +5219,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "Apache-2.0",
       "dependencies": {
-        "pepr": "^0.13.1"
+        "pepr": "^0.13.2"
       },
       "devDependencies": {
         "ava": "5.3.1",
@@ -3669,9 +3669,9 @@
       }
     },
     "node_modules/pepr": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/pepr/-/pepr-0.13.1.tgz",
-      "integrity": "sha512-STG8wEwvravWIxLvasnD9GMnpRDDETcYSIjOiLKZVZxi2sutiVc54wfEQyGVhaw6DmjwmO8JXppFMHUjN4d9Hw==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/pepr/-/pepr-0.13.2.tgz",
+      "integrity": "sha512-ywZ5TJktDDeOdWV8mMtejKmJXkQVm1D3nXIpbe5SSi9tlmwqMh+E/F+laMoBZeAA9moIuVCqbzAd/w/54cfWbg==",
       "dependencies": {
         "@kubernetes/client-node": "0.18.1",
         "express": "4.18.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,11 @@
       "version": "0.0.0-development",
       "license": "Apache-2.0",
       "dependencies": {
-        "pepr": "0.x.x"
+        "pepr": "file:../shifting-sands/pepr/pepr-0.0.0-development.tgz"
       },
       "devDependencies": {
-        "ava": "5.3.1",
-        "ts-node": "10.9.1",
-        "typescript": "5.0.4"
+        "ava": "5.3.x",
+        "typescript": "5.1.6"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -29,22 +28,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
-      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.15.tgz",
+      "integrity": "sha512-wlkQBWb79/jeEEoRmrxt/yhn5T1lU236OCNpnfRzaCJHZ/5gf82uYx1qmADTBWE0AR/v7FiozE1auk2riyQd3w==",
       "cpu": [
         "arm"
       ],
@@ -58,9 +45,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
-      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.15.tgz",
+      "integrity": "sha512-NI/gnWcMl2kXt1HJKOn2H69SYn4YNheKo6NZt1hyfKWdMbaGadxjZIkcj4Gjk/WPxnbFXs9/3HjGHaknCqjrww==",
       "cpu": [
         "arm64"
       ],
@@ -74,9 +61,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
-      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.15.tgz",
+      "integrity": "sha512-FM9NQamSaEm/IZIhegF76aiLnng1kEsZl2eve/emxDeReVfRuRNmvT28l6hoFD9TsCxpK+i4v8LPpEj74T7yjA==",
       "cpu": [
         "x64"
       ],
@@ -90,9 +77,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
-      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.15.tgz",
+      "integrity": "sha512-XmrFwEOYauKte9QjS6hz60FpOCnw4zaPAb7XV7O4lx1r39XjJhTN7ZpXqJh4sN6q60zbP6QwAVVA8N/wUyBH/w==",
       "cpu": [
         "arm64"
       ],
@@ -106,9 +93,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
-      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.15.tgz",
+      "integrity": "sha512-bMqBmpw1e//7Fh5GLetSZaeo9zSC4/CMtrVFdj+bqKPGJuKyfNJ5Nf2m3LknKZTS+Q4oyPiON+v3eaJ59sLB5A==",
       "cpu": [
         "x64"
       ],
@@ -122,9 +109,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
-      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.15.tgz",
+      "integrity": "sha512-LoTK5N3bOmNI9zVLCeTgnk5Rk0WdUTrr9dyDAQGVMrNTh9EAPuNwSTCgaKOKiDpverOa0htPcO9NwslSE5xuLA==",
       "cpu": [
         "arm64"
       ],
@@ -138,9 +125,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
-      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.15.tgz",
+      "integrity": "sha512-62jX5n30VzgrjAjOk5orYeHFq6sqjvsIj1QesXvn5OZtdt5Gdj0vUNJy9NIpjfdNdqr76jjtzBJKf+h2uzYuTQ==",
       "cpu": [
         "x64"
       ],
@@ -154,9 +141,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
-      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.15.tgz",
+      "integrity": "sha512-dT4URUv6ir45ZkBqhwZwyFV6cH61k8MttIwhThp2BGiVtagYvCToF+Bggyx2VI57RG4Fbt21f9TmXaYx0DeUJg==",
       "cpu": [
         "arm"
       ],
@@ -170,9 +157,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
-      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.15.tgz",
+      "integrity": "sha512-BWncQeuWDgYv0jTNzJjaNgleduV4tMbQjmk/zpPh/lUdMcNEAxy+jvneDJ6RJkrqloG7tB9S9rCrtfk/kuplsQ==",
       "cpu": [
         "arm64"
       ],
@@ -186,9 +173,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
-      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.15.tgz",
+      "integrity": "sha512-JPXORvgHRHITqfms1dWT/GbEY89u848dC08o0yK3fNskhp0t2TuNUnsrrSgOdH28ceb1hJuwyr8R/1RnyPwocw==",
       "cpu": [
         "ia32"
       ],
@@ -202,9 +189,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
-      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.15.tgz",
+      "integrity": "sha512-kArPI0DopjJCEplsVj/H+2Qgzz7vdFSacHNsgoAKpPS6W/Ndh8Oe24HRDQ5QCu4jHgN6XOtfFfLpRx3TXv/mEg==",
       "cpu": [
         "loong64"
       ],
@@ -218,9 +205,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
-      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.15.tgz",
+      "integrity": "sha512-b/tmngUfO02E00c1XnNTw/0DmloKjb6XQeqxaYuzGwHe0fHVgx5/D6CWi+XH1DvkszjBUkK9BX7n1ARTOst59w==",
       "cpu": [
         "mips64el"
       ],
@@ -234,9 +221,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
-      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.15.tgz",
+      "integrity": "sha512-KXPY69MWw79QJkyvUYb2ex/OgnN/8N/Aw5UDPlgoRtoEfcBqfeLodPr42UojV3NdkoO4u10NXQdamWm1YEzSKw==",
       "cpu": [
         "ppc64"
       ],
@@ -250,9 +237,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
-      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.15.tgz",
+      "integrity": "sha512-komK3NEAeeGRnvFEjX1SfVg6EmkfIi5aKzevdvJqMydYr9N+pRQK0PGJXk+bhoPZwOUgLO4l99FZmLGk/L1jWg==",
       "cpu": [
         "riscv64"
       ],
@@ -266,9 +253,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
-      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.15.tgz",
+      "integrity": "sha512-632T5Ts6gQ2WiMLWRRyeflPAm44u2E/s/TJvn+BP6M5mnHSk93cieaypj3VSMYO2ePTCRqAFXtuYi1yv8uZJNA==",
       "cpu": [
         "s390x"
       ],
@@ -282,9 +269,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
-      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.15.tgz",
+      "integrity": "sha512-MsHtX0NgvRHsoOtYkuxyk4Vkmvk3PLRWfA4okK7c+6dT0Fu4SUqXAr9y4Q3d8vUf1VWWb6YutpL4XNe400iQ1g==",
       "cpu": [
         "x64"
       ],
@@ -298,9 +285,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
-      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.15.tgz",
+      "integrity": "sha512-djST6s+jQiwxMIVQ5rlt24JFIAr4uwUnzceuFL7BQT4CbrRtqBPueS4GjXSiIpmwVri1Icj/9pFRJ7/aScvT+A==",
       "cpu": [
         "x64"
       ],
@@ -314,9 +301,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
-      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.15.tgz",
+      "integrity": "sha512-naeRhUIvhsgeounjkF5mvrNAVMGAm6EJWiabskeE5yOeBbLp7T89tAEw0j5Jm/CZAwyLe3c67zyCWH6fsBLCpw==",
       "cpu": [
         "x64"
       ],
@@ -330,9 +317,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
-      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.15.tgz",
+      "integrity": "sha512-qkT2+WxyKbNIKV1AEhI8QiSIgTHMcRctzSaa/I3kVgMS5dl3fOeoqkb7pW76KwxHoriImhx7Mg3TwN/auMDsyQ==",
       "cpu": [
         "x64"
       ],
@@ -346,9 +333,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
-      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.15.tgz",
+      "integrity": "sha512-HC4/feP+pB2Vb+cMPUjAnFyERs+HJN7E6KaeBlFdBv799MhD+aPJlfi/yk36SED58J9TPwI8MAcVpJgej4ud0A==",
       "cpu": [
         "arm64"
       ],
@@ -362,9 +349,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
-      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.15.tgz",
+      "integrity": "sha512-ovjwoRXI+gf52EVF60u9sSDj7myPixPxqzD5CmkEUmvs+W9Xd0iqISVBQn8xcx4ciIaIVlWCuTbYDOXOnOL44Q==",
       "cpu": [
         "ia32"
       ],
@@ -378,9 +365,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
-      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.15.tgz",
+      "integrity": "sha512-imUxH9a3WJARyAvrG7srLyiK73XdX83NXQkjKvQ+7vPh3ZxoLrzvPkQKKw2DwZ+RV2ZB6vBfNHP8XScAmQC3aA==",
       "cpu": [
         "x64"
       ],
@@ -409,18 +396,18 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.7.0.tgz",
+      "integrity": "sha512-+HencqxU7CFJnQb7IKtuNBqS6Yx3Tz4kOL8BJXo+JyeiBm5MEX6pO8onXDkjrkCRlfYXS1Axro15ZjVFe9YgsA==",
       "peer": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
-      "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
       "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -441,9 +428,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.41.0.tgz",
-      "integrity": "sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==",
+      "version": "8.44.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
+      "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
       "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -482,31 +469,6 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "peer": true
     },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
     "node_modules/@kubernetes/client-node": {
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.18.1.tgz",
@@ -532,11 +494,6 @@
       "optionalDependencies": {
         "openid-client": "^5.3.0"
       }
-    },
-    "node_modules/@kubernetes/client-node/node_modules/@types/node": {
-      "version": "18.16.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.19.tgz",
-      "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -570,30 +527,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true
-    },
     "node_modules/@types/caseless": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
@@ -611,9 +544,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "20.4.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz",
-      "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw=="
+      "version": "18.17.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.7.tgz",
+      "integrity": "sha512-WJj/p/cIg6zUsxv1n2leZHpvn8hr9TYuLQxAZxZcK/7+5t5ukmJGelOLGOy3L1MLhAO/sapTJGd1V7kvoIuzUg=="
     },
     "node_modules/@types/request": {
       "version": "2.48.8",
@@ -646,32 +579,34 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.59.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.7.tgz",
-      "integrity": "sha512-BL+jYxUFIbuYwy+4fF86k5vdT9lT0CNJ6HtwrIvGh0PhH8s0yy5rjaKH2fDCrz5ITHy07WCzVGNvAmjJh4IJFA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.1.0.tgz",
+      "integrity": "sha512-qg7Bm5TyP/I7iilGyp6DRqqkt8na00lI6HbjWZObgk3FFSzH5ypRwAHXJhJkwiRtTcfn+xYQIMOR5kJgpo6upw==",
       "peer": true,
       "dependencies": {
-        "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.59.7",
-        "@typescript-eslint/type-utils": "5.59.7",
-        "@typescript-eslint/utils": "5.59.7",
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.1.0",
+        "@typescript-eslint/type-utils": "6.1.0",
+        "@typescript-eslint/utils": "6.1.0",
+        "@typescript-eslint/visitor-keys": "6.1.0",
         "debug": "^4.3.4",
-        "grapheme-splitter": "^1.0.4",
-        "ignore": "^5.2.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
         "natural-compare-lite": "^1.4.0",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -680,25 +615,26 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.59.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.7.tgz",
-      "integrity": "sha512-VhpsIEuq/8i5SF+mPg9jSdIwgMBBp0z9XqjiEay+81PYLJuroN+ET1hM5IhkiYMJd9MkTz8iJLt7aaGAgzWUbQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.1.0.tgz",
+      "integrity": "sha512-hIzCPvX4vDs4qL07SYzyomamcs2/tQYXg5DtdAfj35AyJ5PIUqhsLf4YrEIFzZcND7R2E8tpQIZKayxg8/6Wbw==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.59.7",
-        "@typescript-eslint/types": "5.59.7",
-        "@typescript-eslint/typescript-estree": "5.59.7",
+        "@typescript-eslint/scope-manager": "6.1.0",
+        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/typescript-estree": "6.1.0",
+        "@typescript-eslint/visitor-keys": "6.1.0",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -707,16 +643,16 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.59.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.7.tgz",
-      "integrity": "sha512-FL6hkYWK9zBGdxT2wWEd2W8ocXMu3K94i3gvMrjXpx+koFYdYV7KprKfirpgY34vTGzEPPuKoERpP8kD5h7vZQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.1.0.tgz",
+      "integrity": "sha512-AxjgxDn27hgPpe2rQe19k0tXw84YCOsjDJ2r61cIebq1t+AIxbgiXKvD4999Wk49GVaAcdJ/d49FYel+Pp3jjw==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.7",
-        "@typescript-eslint/visitor-keys": "5.59.7"
+        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/visitor-keys": "6.1.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -724,25 +660,25 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.59.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.7.tgz",
-      "integrity": "sha512-ozuz/GILuYG7osdY5O5yg0QxXUAEoI4Go3Do5xeu+ERH9PorHBPSdvD3Tjp2NN2bNLh1NJQSsQu2TPu/Ly+HaQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.1.0.tgz",
+      "integrity": "sha512-kFXBx6QWS1ZZ5Ni89TyT1X9Ag6RXVIVhqDs0vZE/jUeWlBv/ixq2diua6G7ece6+fXw3TvNRxP77/5mOMusx2w==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.59.7",
-        "@typescript-eslint/utils": "5.59.7",
+        "@typescript-eslint/typescript-estree": "6.1.0",
+        "@typescript-eslint/utils": "6.1.0",
         "debug": "^4.3.4",
-        "tsutils": "^3.21.0"
+        "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "*"
+        "eslint": "^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -751,12 +687,12 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.59.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.7.tgz",
-      "integrity": "sha512-UnVS2MRRg6p7xOSATscWkKjlf/NDKuqo5TdbWck6rIRZbmKpVNTLALzNvcjIfHBE7736kZOFc/4Z3VcZwuOM/A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.1.0.tgz",
+      "integrity": "sha512-+Gfd5NHCpDoHDOaU/yIF3WWRI2PcBRKKpP91ZcVbL0t5tQpqYWBs3z/GGhvU+EV1D0262g9XCnyqQh19prU0JQ==",
       "peer": true,
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -764,21 +700,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.59.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.7.tgz",
-      "integrity": "sha512-4A1NtZ1I3wMN2UGDkU9HMBL+TIQfbrh4uS0WDMMpf3xMRursDbqEf1ahh6vAAe3mObt8k3ZATnezwG4pdtWuUQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.1.0.tgz",
+      "integrity": "sha512-nUKAPWOaP/tQjU1IQw9sOPCDavs/iU5iYLiY/6u7gxS7oKQoi4aUxXS1nrrVGTyBBaGesjkcwwHkbkiD5eBvcg==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.7",
-        "@typescript-eslint/visitor-keys": "5.59.7",
+        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/visitor-keys": "6.1.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -791,42 +727,41 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.59.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.7.tgz",
-      "integrity": "sha512-yCX9WpdQKaLufz5luG4aJbOpdXf/fjwGMcLFXZVPUz3QqLirG5QcwwnIHNf8cjLjxK4qtzTO8udUtMQSAToQnQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.1.0.tgz",
+      "integrity": "sha512-wp652EogZlKmQoMS5hAvWqRKplXvkuOnNzZSE0PVvsKjpexd/XznRVHAtrfHFYmqaJz0DFkjlDsGYC9OXw+OhQ==",
       "peer": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@types/json-schema": "^7.0.9",
-        "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.59.7",
-        "@typescript-eslint/types": "5.59.7",
-        "@typescript-eslint/typescript-estree": "5.59.7",
-        "eslint-scope": "^5.1.1",
-        "semver": "^7.3.7"
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.1.0",
+        "@typescript-eslint/types": "6.1.0",
+        "@typescript-eslint/typescript-estree": "6.1.0",
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "eslint": "^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.59.7",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.7.tgz",
-      "integrity": "sha512-tyN+X2jvMslUszIiYbF0ZleP+RqQsFVpGrKI6e0Eet1w8WmhsAtmzaqm8oM8WJQ1ysLwhnsK/4hYHJjOgJVfQQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.1.0.tgz",
+      "integrity": "sha512-yQeh+EXhquh119Eis4k0kYhj9vmFzNpbhM3LftWQVwqVjipCkwHBQOZutcYW+JVkjtTG9k8nrZU1UoNedPDd1A==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.7",
-        "eslint-visitor-keys": "^3.3.0"
+        "@typescript-eslint/types": "6.1.0",
+        "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^16.0.0 || >=18.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -941,12 +876,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1245,9 +1174,9 @@
       }
     },
     "node_modules/callsites": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-4.0.0.tgz",
-      "integrity": "sha512-y3jRROutgpKdz5vzEhWM34TidDU8vkJppF8dszITeb1PQmSqV3DTxyV8G/lyO/DNvtE1YTedehmw9MPZsCBHxQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-4.1.0.tgz",
+      "integrity": "sha512-aBMbD1Xxay75ViYezwT40aQONfr+pSXTHwNKvIXhXD6+LY3F1dLIcceoC5OZKBVHbXcysz1hL9D2w0JJIMXpUw==",
       "dev": true,
       "engines": {
         "node": ">=12.20"
@@ -1503,12 +1432,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
+      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
       "peer": true,
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/common-path-prefix": {
@@ -1586,12 +1515,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1694,15 +1617,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -1773,9 +1687,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
-      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "version": "0.18.15",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.15.tgz",
+      "integrity": "sha512-3WOOLhrvuTGPRzQPU6waSDWrDTnQriia72McWcn6UCi43GhCHrXH4S59hKMeez+IITmdUuUyvbU9JIp+t3xlPQ==",
       "hasInstallScript": true,
       "peer": true,
       "bin": {
@@ -1785,28 +1699,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.17.19",
-        "@esbuild/android-arm64": "0.17.19",
-        "@esbuild/android-x64": "0.17.19",
-        "@esbuild/darwin-arm64": "0.17.19",
-        "@esbuild/darwin-x64": "0.17.19",
-        "@esbuild/freebsd-arm64": "0.17.19",
-        "@esbuild/freebsd-x64": "0.17.19",
-        "@esbuild/linux-arm": "0.17.19",
-        "@esbuild/linux-arm64": "0.17.19",
-        "@esbuild/linux-ia32": "0.17.19",
-        "@esbuild/linux-loong64": "0.17.19",
-        "@esbuild/linux-mips64el": "0.17.19",
-        "@esbuild/linux-ppc64": "0.17.19",
-        "@esbuild/linux-riscv64": "0.17.19",
-        "@esbuild/linux-s390x": "0.17.19",
-        "@esbuild/linux-x64": "0.17.19",
-        "@esbuild/netbsd-x64": "0.17.19",
-        "@esbuild/openbsd-x64": "0.17.19",
-        "@esbuild/sunos-x64": "0.17.19",
-        "@esbuild/win32-arm64": "0.17.19",
-        "@esbuild/win32-ia32": "0.17.19",
-        "@esbuild/win32-x64": "0.17.19"
+        "@esbuild/android-arm": "0.18.15",
+        "@esbuild/android-arm64": "0.18.15",
+        "@esbuild/android-x64": "0.18.15",
+        "@esbuild/darwin-arm64": "0.18.15",
+        "@esbuild/darwin-x64": "0.18.15",
+        "@esbuild/freebsd-arm64": "0.18.15",
+        "@esbuild/freebsd-x64": "0.18.15",
+        "@esbuild/linux-arm": "0.18.15",
+        "@esbuild/linux-arm64": "0.18.15",
+        "@esbuild/linux-ia32": "0.18.15",
+        "@esbuild/linux-loong64": "0.18.15",
+        "@esbuild/linux-mips64el": "0.18.15",
+        "@esbuild/linux-ppc64": "0.18.15",
+        "@esbuild/linux-riscv64": "0.18.15",
+        "@esbuild/linux-s390x": "0.18.15",
+        "@esbuild/linux-x64": "0.18.15",
+        "@esbuild/netbsd-x64": "0.18.15",
+        "@esbuild/openbsd-x64": "0.18.15",
+        "@esbuild/sunos-x64": "0.18.15",
+        "@esbuild/win32-arm64": "0.18.15",
+        "@esbuild/win32-ia32": "0.18.15",
+        "@esbuild/win32-x64": "0.18.15"
       }
     },
     "node_modules/escalade": {
@@ -1836,16 +1750,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.41.0.tgz",
-      "integrity": "sha512-WQDQpzGBOP5IrXPo4Hc0814r4/v2rrIsB0rhT7jtunIalgg6gYXWhRMOejVO8yH21T/FGaxjmFjBMNqcIlmH1Q==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
+      "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.0.3",
-        "@eslint/js": "8.41.0",
-        "@humanwhocodes/config-array": "^0.11.8",
+        "@eslint/eslintrc": "^2.1.0",
+        "@eslint/js": "8.44.0",
+        "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
@@ -1856,7 +1770,7 @@
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^7.2.0",
         "eslint-visitor-keys": "^3.4.1",
-        "espree": "^9.5.2",
+        "espree": "^9.6.0",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -1866,7 +1780,6 @@
         "globals": "^13.19.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
@@ -1876,9 +1789,8 @@
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
+        "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
       },
       "bin": {
@@ -1892,22 +1804,25 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
+        "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1956,31 +1871,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "peer": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/eslint/node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2006,9 +1896,9 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
-      "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "peer": true,
       "dependencies": {
         "acorn": "^8.9.0",
@@ -2047,15 +1937,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/esquery/node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "peer": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/esrecurse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -2068,19 +1949,10 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/esrecurse/node_modules/estraverse": {
+    "node_modules/estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "peer": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "peer": true,
       "engines": {
         "node": ">=4.0"
@@ -2181,9 +2053,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -2400,9 +2272,9 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -2480,9 +2352,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
       "peer": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -2513,12 +2385,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/grapheme-splitter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-      "peer": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -2983,12 +2849,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
     },
     "node_modules/map-age-cleaner": {
       "version": "0.1.3",
@@ -3511,16 +3371,17 @@
       }
     },
     "node_modules/pepr": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/pepr/-/pepr-0.12.1.tgz",
-      "integrity": "sha512-W/WEuTC//6Nhab5j6JeGzB+aGxP74CcPo/ZlT7iBmNXJ1XZAeUT/ctgEBgJFhWAE9Ln5g4ha2RJOhLj/VzVi4A==",
+      "version": "0.0.0-development",
+      "resolved": "file:../shifting-sands/pepr/pepr-0.0.0-development.tgz",
+      "integrity": "sha512-ytVFWxnqMRuVAUtBdSq26Is9BVs/ZyeEClf8RDyYj7TsnCogUXdEXNpXBbiRxeMnJODyWS/VlSPA2Y/gpct/Ag==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "0.18.1",
         "express": "4.18.2",
         "fast-json-patch": "3.1.1",
         "http-status-codes": "2.2.0",
         "node-fetch": "2.6.12",
-        "prom-client": "^14.2.0",
+        "prom-client": "14.2.0",
         "ramda": "0.29.0"
       },
       "bin": {
@@ -3530,15 +3391,15 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "5.59.7",
-        "@typescript-eslint/parser": "5.59.7",
-        "commander": "10.0.1",
-        "esbuild": "0.17.19",
-        "eslint": "8.41.0",
+        "@typescript-eslint/eslint-plugin": "6.1.0",
+        "@typescript-eslint/parser": "6.1.0",
+        "commander": "11.0.0",
+        "esbuild": "0.18.15",
+        "eslint": "8.45.0",
         "node-forge": "1.3.1",
-        "prettier": "2.8.8",
+        "prettier": "3.0.0",
         "prompts": "2.4.2",
-        "typescript": "5.0.4",
+        "typescript": "5.1.6",
         "uuid": "9.0.0"
       }
     },
@@ -3681,15 +3542,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
       "peer": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -4140,9 +4001,9 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
-      "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "engines": {
         "node": ">=14"
@@ -4445,74 +4306,22 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
-    "node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
+    "node_modules/ts-api-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.2.tgz",
+      "integrity": "sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=16.13.0"
       },
       "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
+        "typescript": ">=4.2.0"
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
-    },
-    "node_modules/tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-      }
-    },
-    "node_modules/tsutils/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "peer": true
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -4567,15 +4376,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/underscore": {
@@ -4615,12 +4424,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -4890,15 +4693,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "Apache-2.0",
       "dependencies": {
-        "pepr": "^0.13.0"
+        "pepr": "^0.13.1"
       },
       "devDependencies": {
         "ava": "5.3.1",
@@ -449,9 +449,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
+      "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
       "peer": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -533,9 +533,9 @@
       }
     },
     "node_modules/@kubernetes/client-node/node_modules/@types/node": {
-      "version": "18.17.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.12.tgz",
-      "integrity": "sha512-d6xjC9fJ/nSnfDeU0AMDsaJyb1iHsqCSOdi84w4u+SlN/UgQdY5tRhpMzaFYsI4mnpvgTivEaQd0yOUhAtOnEQ=="
+      "version": "18.17.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.14.tgz",
+      "integrity": "sha512-ZE/5aB73CyGqgQULkLG87N9GnyGe5TcQjv34pwS8tfBs1IkCh0ASM69mydb2znqd6v0eX+9Ytvk6oQRqu8T1Vw=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -594,9 +594,9 @@
       "dev": true
     },
     "node_modules/@types/caseless": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.3.tgz",
+      "integrity": "sha512-ZD/NsIJYq/2RH+hY7lXmstfp/v9djGt9ah+xRQ3pcgR79qiKsG4pLl25AI7IcXxVO8dH9GiBE5rAknC0ePntlw=="
     },
     "node_modules/@types/js-yaml": {
       "version": "4.0.5",
@@ -610,9 +610,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "20.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
-      "integrity": "sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA=="
+      "version": "20.5.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
+      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ=="
     },
     "node_modules/@types/request": {
       "version": "2.48.8",
@@ -645,16 +645,16 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.0.tgz",
-      "integrity": "sha512-62o2Hmc7Gs3p8SLfbXcipjWAa6qk2wZGChXG2JbBtYpwSRmti/9KHLqfbLs9uDigOexG+3PaQ9G2g3201FWLKg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.5.0.tgz",
+      "integrity": "sha512-2pktILyjvMaScU6iK3925uvGU87E+N9rh372uGZgiMYwafaw9SXq86U04XPq3UH6tzRvNgBsub6x2DacHc33lw==",
       "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.4.0",
-        "@typescript-eslint/type-utils": "6.4.0",
-        "@typescript-eslint/utils": "6.4.0",
-        "@typescript-eslint/visitor-keys": "6.4.0",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/type-utils": "6.5.0",
+        "@typescript-eslint/utils": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -680,15 +680,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.0.tgz",
-      "integrity": "sha512-I1Ah1irl033uxjxO9Xql7+biL3YD7w9IU8zF+xlzD/YxY6a4b7DYA08PXUUCbm2sEljwJF6ERFy2kTGAGcNilg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.5.0.tgz",
+      "integrity": "sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.4.0",
-        "@typescript-eslint/types": "6.4.0",
-        "@typescript-eslint/typescript-estree": "6.4.0",
-        "@typescript-eslint/visitor-keys": "6.4.0",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/typescript-estree": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -708,13 +708,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.0.tgz",
-      "integrity": "sha512-TUS7vaKkPWDVvl7GDNHFQMsMruD+zhkd3SdVW0d7b+7Zo+bd/hXJQ8nsiUZMi1jloWo6c9qt3B7Sqo+flC1nig==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.5.0.tgz",
+      "integrity": "sha512-A8hZ7OlxURricpycp5kdPTH3XnjG85UpJS6Fn4VzeoH4T388gQJ/PGP4ole5NfKt4WDVhmLaQ/dBLNDC4Xl/Kw==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.0",
-        "@typescript-eslint/visitor-keys": "6.4.0"
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -725,13 +725,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.4.0.tgz",
-      "integrity": "sha512-TvqrUFFyGY0cX3WgDHcdl2/mMCWCDv/0thTtx/ODMY1QhEiyFtv/OlLaNIiYLwRpAxAtOLOY9SUf1H3Q3dlwAg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.5.0.tgz",
+      "integrity": "sha512-f7OcZOkRivtujIBQ4yrJNIuwyCQO1OjocVqntl9dgSIZAdKqicj3xFDqDOzHDlGCZX990LqhLQXWRnQvsapq8A==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.4.0",
-        "@typescript-eslint/utils": "6.4.0",
+        "@typescript-eslint/typescript-estree": "6.5.0",
+        "@typescript-eslint/utils": "6.5.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -752,9 +752,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.0.tgz",
-      "integrity": "sha512-+FV9kVFrS7w78YtzkIsNSoYsnOtrYVnKWSTVXoL1761CsCRv5wpDOINgsXpxD67YCLZtVQekDDyaxfjVWUJmmg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.5.0.tgz",
+      "integrity": "sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==",
       "peer": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -765,13 +765,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.0.tgz",
-      "integrity": "sha512-iDPJArf/K2sxvjOR6skeUCNgHR/tCQXBsa+ee1/clRKr3olZjZ/dSkXPZjG6YkPtnW6p5D1egeEPMCW6Gn4yLA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.5.0.tgz",
+      "integrity": "sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.0",
-        "@typescript-eslint/visitor-keys": "6.4.0",
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -792,17 +792,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.0.tgz",
-      "integrity": "sha512-BvvwryBQpECPGo8PwF/y/q+yacg8Hn/2XS+DqL/oRsOPK+RPt29h5Ui5dqOKHDlbXrAeHUTnyG3wZA0KTDxRZw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.5.0.tgz",
+      "integrity": "sha512-9nqtjkNykFzeVtt9Pj6lyR9WEdd8npPhhIPM992FWVkZuS6tmxHfGVnlUcjpUP2hv8r4w35nT33mlxd+Be1ACQ==",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.4.0",
-        "@typescript-eslint/types": "6.4.0",
-        "@typescript-eslint/typescript-estree": "6.4.0",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/typescript-estree": "6.5.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -817,12 +817,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.0.tgz",
-      "integrity": "sha512-yJSfyT+uJm+JRDWYRYdCm2i+pmvXJSMtPR9Cq5/XQs4QIgNoLcoRtDdzsLbLsFM/c6um6ohQkg/MLxWvoIndJA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.5.0.tgz",
+      "integrity": "sha512-yCB/2wkbv3hPsh02ZS8dFQnij9VVQXJMN/gbQsaaY+zxALkZnxa/wagvLEFsAWMPv7d7lxQmNsIzGU1w/T/WyA==",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.0",
+        "@typescript-eslint/types": "6.5.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -1918,15 +1918,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.47.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.47.0.tgz",
-      "integrity": "sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==",
+      "version": "8.48.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.48.0.tgz",
+      "integrity": "sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "^8.47.0",
+        "@eslint/js": "8.48.0",
         "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -2964,9 +2964,9 @@
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
     "node_modules/jose": {
-      "version": "4.14.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.4.tgz",
-      "integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==",
+      "version": "4.14.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.6.tgz",
+      "integrity": "sha512-EqJPEUlZD0/CSUMubKtMaYUOtWe91tZXTWMJZoKSbLk+KtdhNdcvppH8lA9XwVu2V4Ailvsj0GBZJ2ZwDjfesQ==",
       "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -3669,9 +3669,9 @@
       }
     },
     "node_modules/pepr": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/pepr/-/pepr-0.13.0.tgz",
-      "integrity": "sha512-5v7Iz6L0X0Dobjwozbbd7yASC2peZv5Yhm22oPgRSPkcL6KnYwwby6yB3fbreGHlBEjM5Qinq5FoHhzbbQoATg==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/pepr/-/pepr-0.13.1.tgz",
+      "integrity": "sha512-STG8wEwvravWIxLvasnD9GMnpRDDETcYSIjOiLKZVZxi2sutiVc54wfEQyGVhaw6DmjwmO8JXppFMHUjN4d9Hw==",
       "dependencies": {
         "@kubernetes/client-node": "0.18.1",
         "express": "4.18.2",
@@ -3690,15 +3690,15 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "6.4.0",
-        "@typescript-eslint/parser": "6.4.0",
+        "@typescript-eslint/eslint-plugin": "6.5.0",
+        "@typescript-eslint/parser": "6.5.0",
         "commander": "11.0.0",
         "esbuild": "0.19.2",
-        "eslint": "8.47.0",
+        "eslint": "8.48.0",
         "node-forge": "1.3.1",
-        "prettier": "3.0.1",
+        "prettier": "3.0.3",
         "prompts": "2.4.2",
-        "typescript": "5.1.6",
+        "typescript": "5.2.2",
         "uuid": "9.0.0"
       }
     },
@@ -3900,9 +3900,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.1.tgz",
-      "integrity": "sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -4667,9 +4667,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
-      "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
+      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -4890,9 +4890,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -32,17 +32,16 @@
     }
   },
   "scripts": {
-    "build": "rm -fr dist && pepr build -e index.ts",
+    "build": "rm -fr dist && npx pepr build -e index.ts",
     "k3d-setup": "k3d cluster delete pepr-dev && k3d cluster create pepr-dev --k3s-arg '--debug@server:0' -p '443:443@loadbalancer' -p '80:80@loadbalancer' --k3s-arg='--disable=traefik@server:0'",
     "test": "ava"
   },
   "dependencies": {
-    "pepr": "0.x.x"
+     "pepr": "file:../shifting-sands/pepr/pepr-0.0.0-development.tgz"
   },
   "devDependencies": {
     "ava": "5.3.1",
-    "ts-node": "10.9.1",
-    "typescript": "5.0.4"
+    "typescript": "5.1.6"
   },
   "ava": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "test": "ava"
   },
   "dependencies": {
-     "pepr": "file:../shifting-sands/pepr/pepr-0.0.0-development.tgz"
+    "pepr": "^0.13.0"
   },
   "devDependencies": {
     "ava": "5.3.1",
-    "typescript": "5.1.6"
+    "ts-node": "10.9.1"
   },
   "ava": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test": "ava"
   },
   "dependencies": {
-    "pepr": "^0.13.1"
+    "pepr": "^0.13.2"
   },
   "devDependencies": {
     "ava": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test": "ava"
   },
   "dependencies": {
-    "pepr": "^0.13.0"
+    "pepr": "^0.13.1"
   },
   "devDependencies": {
     "ava": "5.3.1",


### PR DESCRIPTION
updated to support pepr (0.13.x) with the new mutate and validate callbacks, added ownerreferneces, removed direct call to kubernetes-client, using

the lib exposes by pepr